### PR TITLE
Fix ByteBufferProvider#asByteBuffers order, close #72

### DIFF
--- a/boopickle/shared/src/main/scala/boopickle/BufferProvider.scala
+++ b/boopickle/shared/src/main/scala/boopickle/BufferProvider.scala
@@ -69,7 +69,7 @@ abstract class ByteBufferProvider extends BufferProvider {
 
   def asByteBuffers = {
     currentBuf.flip()
-    (currentBuf :: buffers).toVector
+    (currentBuf :: buffers).reverse.toVector
   }
 }
 

--- a/boopickle/shared/src/test/scala/boopickle/BufferProviderTests.scala
+++ b/boopickle/shared/src/test/scala/boopickle/BufferProviderTests.scala
@@ -1,0 +1,28 @@
+package boopickle
+
+import java.nio.ByteBuffer
+
+import scala.util.Random
+
+import external.Banana
+import utest._
+import boopickle.Default._
+
+object BufferProviderTests extends TestSuite {
+
+  override def tests = TestSuite {
+    'asByteBuffersProperOrder {
+
+      val input: Seq[Banana] = Iterator.tabulate(100)(_ => Banana(Random.nextDouble)).toVector
+      val bbs = Pickle.intoByteBuffers(input)
+      assert(bbs.size > 1)
+
+      val mergedBb = ByteBuffer.allocate(bbs.map(_.remaining).sum)
+      bbs.foreach(mergedBb.put)
+      mergedBb.flip()
+
+      val output = Unpickle[Seq[Banana]].fromBytes(mergedBb)
+      assert(output == input)
+    }
+  }
+}


### PR DESCRIPTION
Motivation:

`ByteBufferProvider#asByteBuffers` currently returns ByteBuffers is
reverse order, which is unexpected.
One would expect them to be in proper temporal order.

Modifications:

* Reverse ByteBuffer sequence order before returning
* Add test proving proper behavior

Result:

ByteBufferProvider#asByteBuffers now returns in proper order