### PR TITLE
add pickler derivation with shapeless

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jdk:
 node_js:
 - 8
 script:
-- sbt ++$TRAVIS_SCALA_VERSION boopickleJVM/test boopickleJS/test
+- sbt ++$TRAVIS_SCALA_VERSION boopickleJVM/test boopickleJS/test shapelessJVM/test shapelessJS/test
 # Tricks to avoid unnecessary cache updates, from
 # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
 - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -2,11 +2,11 @@
 
 Add following dependency declaration to your Scala project 
 
-<pre><code class="lang-scala">"me.chrons" %% "boopickle" % "{{ book.version }}"</code></pre>
+<pre><code class="lang-scala">"io.suzaku" %% "boopickle" % "{{ book.version }}"</code></pre>
 
 On a Scala.js project the dependency looks like this
 
-<pre><code class="lang-scala">"me.chrons" %%% "boopickle" % "{{ book.version }}"</code></pre>
+<pre><code class="lang-scala">"io.suzaku" %%% "boopickle" % "{{ book.version }}"</code></pre>
 
 To use it in your code, simply import the Default object contents. All examples in this document assume this import is present.
 

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -4,6 +4,7 @@
 * [Getting started](GettingStarted.md)
 * [Class hierarchies](ClassHierarchies.md)
 * [Advanced pickling](AdvancedPickling.md)
+* [Shapeless bindings](Shapeless.md)
 * [Optimization](Optimization.md)
 * [Internal details](Details.md)
 * [Miscellaneous](Misc.md)

--- a/doc/Shapeless.md
+++ b/doc/Shapeless.md
@@ -1,0 +1,11 @@
+# Shapeless bindings
+
+BooPickle provides bindings for shapeless. You can use them by adding the following dependency to your Scala project:
+
+<pre><code class="lang-scala">"io.suzaku" %% "boopickle-shapeless" % "{{ book.version }}"</code></pre>
+
+This module can be used instead of the default macro implementation for automatically deriving picklers of case classes, ADT hierarchies and tuples. You can use it in your code by importing:
+
+```scala
+import boopickle.shapeless.Default._ // instead of boopickle.Default._
+```

--- a/shapeless/src/main/scala/boopickle/shapeless/Default.scala
+++ b/shapeless/src/main/scala/boopickle/shapeless/Default.scala
@@ -1,0 +1,8 @@
+package boopickle.shapeless
+
+import boopickle._
+
+object Default extends Base with BasicImplicitPicklers with ShapelessPicklers {
+
+  def generatePickler[T](implicit pickler: Pickler[T]): Pickler[T] = pickler
+}

--- a/shapeless/src/main/scala/boopickle/shapeless/ShapelessPicklers.scala
+++ b/shapeless/src/main/scala/boopickle/shapeless/ShapelessPicklers.scala
@@ -1,0 +1,51 @@
+package boopickle.shapeless
+
+import boopickle._
+import _root_.shapeless._
+
+import java.nio.ByteBuffer
+import scala.reflect.ClassTag
+
+trait ShapelessPicklers extends TransformPicklers {
+  implicit def hconsPickler[H, T <: HList](implicit hp: Lazy[Pickler[H]], tp: Lazy[Pickler[T]]): Pickler[H :: T] = new Pickler[H :: T] {
+    override def pickle(list: H :: T)(implicit state: PickleState): Unit = {
+      val head :: tail = list
+      hp.value.pickle(head)
+      tp.value.pickle(tail)
+    }
+
+    override def unpickle(implicit state: UnpickleState): H :: T = {
+      val head = hp.value.unpickle
+      val tail = tp.value.unpickle
+      head :: tail
+    }
+  }
+
+  implicit val hnilPickler: Pickler[HNil] = new Pickler[HNil] {
+    override def pickle(list: HNil)(implicit state: PickleState): Unit = ()
+    override def unpickle(implicit state: UnpickleState): HNil = HNil
+  }
+
+  implicit def genericPickler[A, B](implicit gen: Generic.Aux[A, B], rp: Lazy[Pickler[B]]): Pickler[A] = new Pickler[A] {
+    override def pickle(list: A)(implicit state: PickleState): Unit = rp.value.pickle(gen.to(list))
+    override def unpickle(implicit state: UnpickleState): A = gen.from(rp.value.unpickle)
+  }
+
+  implicit def coproductInlPickler[A, B <: Coproduct](implicit ap: Lazy[Pickler[A]]): Pickler[Inl[A, B]] =  {
+    transformPickler[Inl[A, B], A](a => Inl(a))(_.head)(ap.value)
+  }
+
+  implicit def coproductInrPickler[A, B <: Coproduct](implicit bp: Lazy[Pickler[B]]): Pickler[Inr[A, B]] =  {
+    transformPickler[Inr[A, B], B](a => Inr(a))(_.tail)(bp.value)
+  }
+
+  implicit def coproductPickler[A : ClassTag, B <: Coproduct : ClassTag](implicit ap: Lazy[Pickler[A]], bp: Lazy[Pickler[B]]): Pickler[A :+: B] = {
+    CompositePickler[A :+: B].addConcreteType[Inl[A, B]].addConcreteType[Inr[A, B]]
+  }
+
+  implicit def cnilPickler: Pickler[CNil] = new Pickler[CNil] {
+    override def pickle(list: CNil)(implicit state: PickleState): Unit = ()
+    override def unpickle(implicit state: UnpickleState): CNil = ??? // CNil should never be reached
+  }
+}
+object ShapelessPicklers extends ShapelessPicklers

--- a/shapeless/src/test/scala/boopickle/shapeless/external/ShapelessPickleTests.scala
+++ b/shapeless/src/test/scala/boopickle/shapeless/external/ShapelessPickleTests.scala
@@ -1,0 +1,174 @@
+package external
+
+import java.nio.ByteBuffer
+
+import boopickle.shapeless.Default._
+import shapeless._
+import boopickle.{DecoderSize, EncoderSize, UnpickleState}
+import utest._
+
+object ShapelessPickleTests extends TestSuite {
+
+  case class Test1(i: Int, x: String)
+
+  case class Test2(i: Int, next: Option[Test2], l: Map[String, String] = Map.empty)
+
+  case object TestO
+
+  sealed trait MyTrait
+
+  case class TT1(i: Int) extends MyTrait
+
+  sealed trait DeepTrait extends MyTrait
+
+  case class TT2(s: String, next: MyTrait) extends DeepTrait
+
+  class TT3(val i: Int, val s: String) extends DeepTrait {
+    // a normal class requires an equals method to work properly
+    override def equals(obj: scala.Any): Boolean = obj match {
+      case t: TT3 => i == t.i && s == t.s
+      case _      => false
+    }
+  }
+
+  object TT3
+
+  case class A(fills: List[B])
+
+  case class B(stops: List[(Double, Double)])
+
+  sealed trait A1Trait[T]
+
+  case class A1[T](i: T) extends A1Trait[T]
+
+  sealed abstract class AClass
+
+  case class AB(i: Int) extends AClass
+
+  sealed abstract class Version(val number: Int)
+
+  case object V1 extends Version(1)
+
+  case object V2 extends Version(2)
+
+  case class ValueClass(value: Int) extends AnyVal
+
+  sealed trait ValueTrait[T] extends Any
+
+  class ValueTraitClass[T](val value: T) extends AnyVal with ValueTrait[T]
+
+  sealed trait MultiT[S, T, O]
+
+  case class Multi[S,T](s: S, t: T) extends MultiT[S, T, String]
+
+  case class Multi2[S,T](s: S, t: T) extends MultiT[S, T, String]
+
+  override def tests = Tests {
+    'CaseClasses - {
+      'Case1 {
+        val bb = Pickle.intoBytes(Test1(5, "Hello!"))
+        val u = Unpickle[Test1].fromBytes(bb)
+        assert(bb.limit == 1 + 1 + 7 - 1)
+        assert(u == Test1(5, "Hello!"))
+      }
+      'SeqCase {
+        implicit def pstate                              = new PickleState(new EncoderSize, true)
+        implicit def ustate: ByteBuffer => UnpickleState = b => new UnpickleState(new DecoderSize(b), true)
+        val t                                            = Test1(99, "Hello!")
+        val s                                            = Seq(t, t, t)
+        val bb                                           = Pickle.intoBytes(s)
+        assert(bb.limit == 1 + 1 + 1 + 7 + 2 * 2 + 1)
+        val u = Unpickle[Seq[Test1]].fromBytes(bb)
+        assert(u == s)
+      }
+      'Recursive {
+        val t  = List(Test2(1, Some(Test2(2, Some(Test2(3, None))))))
+        val bb = Pickle.intoBytes(t)
+        assert(bb.limit == 13 - 3)
+        val u = Unpickle[List[Test2]].fromBytes(bb)
+        assert(u == t)
+      }
+      'CaseObject {
+        val bb = Pickle.intoBytes(TestO)
+        // yea, pickling a case object takes no space at all :)
+        assert(bb.limit == 0)
+        val u = Unpickle[TestO.type].fromBytes(bb)
+        assert(u == TestO)
+      }
+      'Trait {
+        val t: Seq[MyTrait] = Seq(TT1(5), TT2("five", TT2("six", new TT3(42, "fortytwo"))))
+        val bb              = Pickle.intoBytes(t)
+        val u               = Unpickle[Seq[MyTrait]].fromBytes(bb)
+        assert(u == t)
+      }
+      'TraitToo {
+        // the same test code twice, to check that additional .class files are not generated for the MyTrait pickler
+        val t: Seq[MyTrait] = Seq(TT1(5), TT2("five", TT2("six", new TT3(42, "fortytwo"))))
+        val bb              = Pickle.intoBytes(t)
+        val u               = Unpickle[Seq[MyTrait]].fromBytes(bb)
+        assert(u == t)
+      }
+      'AbstractClass {
+        val t: List[AClass] = List(AB(5), AB(2))
+        val bb             = Pickle.intoBytes(t)
+        val u              = Unpickle[List[AClass]].fromBytes(bb)
+        assert(u == t)
+      }
+      'AbstractClass2 {
+        val t: Seq[Version] = Seq(V1, V2)
+        val bytes           = Pickle.intoBytes(t)
+        val u               = Unpickle[Seq[Version]].fromBytes(bytes)
+        assert(u == t)
+      }
+      'CaseTupleList {
+        val x = A(List(B(List(Tuple2(2.0, 1.0)))))
+        val bb = Pickle.intoBytes(x)
+        val u = Unpickle[A].fromBytes(bb)
+        assert(x == u)
+      }
+      'CaseTupleList2 {
+        implicit val bPickler = generatePickler[B]
+        val x                 = A(List(B(List((2.0, 3.0)))))
+        val bb                = Pickle.intoBytes(x)
+        val u                 = Unpickle[A].fromBytes(bb)
+        assert(x == u)
+      }
+      'CaseTupleList3 {
+        val x  = List(B(List((2.0, 3.0))))
+        val bb = Pickle.intoBytes(x)
+        val u  = Unpickle[List[B]].fromBytes(bb)
+        assert(x == u)
+      }
+      'CaseGenericTraitAndCaseclass {
+        val x: A1Trait[Int] = A1[Int](2)
+        val bb              = Pickle.intoBytes(x)
+        val u               = Unpickle[A1Trait[Int]].fromBytes(bb)
+        assert(x == u)
+      }
+      'CaseGenericTraitAndCaseclass2 {
+        val x: A1Trait[Double] = A1[Double](2.0)
+        val bb                 = Pickle.intoBytes(x)
+        val u                  = Unpickle[A1Trait[Double]].fromBytes(bb)
+        assert(x == u)
+      }
+      'ValueClass {
+        val x: ValueClass = ValueClass(3)
+        val bb            = Pickle.intoBytes(x)
+        val u             = Unpickle[ValueClass].fromBytes(bb)
+        assert(x == u)
+      }
+      'TraitAndValueClass {
+        val x: ValueTrait[Int] = new ValueTraitClass[Int](3)
+        val bb                 = Pickle.intoBytes(x)
+        val u                  = Unpickle[ValueTrait[Int]].fromBytes(bb)
+        assert(x == u)
+      }
+      'MultipleGenerics {
+        val x: MultiT[Int,Double,String] = Multi[Int,Double](1, 2.0)
+        val bb                 = Pickle.intoBytes(x)
+        val u                  = Unpickle[MultiT[Int,Double,String]].fromBytes(bb)
+        assert(x == u)
+      }
+    }
+  }
+}


### PR DESCRIPTION
As mentioned in this issue https://github.com/suzaku-io/boopickle/issues/29, shapeless bindings can be useful and could (maybe?) replace our own macro for generating case class picklers.

This PR adds pickler derivation with shapeless, which coexists with the current macro solution. It adds a `DefaultShapeless` object which uses shapeless for case class, adt and tuple picklers. I have copied the MacroPicklerTests and can run them successfully with shapeless.

These are some minor differences regarding the size of the serialized bytebuffer: I added [-1](https://github.com/cornerman/boopickle/blob/4ad08f788b2398c1cd07aaa4530d59c6538394ca/boopickle/shared/src/test/scala/external/ShapelessPickleTests.scala#L78), [+1](https://github.com/cornerman/boopickle/blob/4ad08f788b2398c1cd07aaa4530d59c6538394ca/boopickle/shared/src/test/scala/external/ShapelessPickleTests.scala#L87) and [-3](https://github.com/cornerman/boopickle/blob/4ad08f788b2398c1cd07aaa4530d59c6538394ca/boopickle/shared/src/test/scala/external/ShapelessPickleTests.scala#L94) to the expected bytes. 

What do you think?