### PR TITLE
Add jitpack.yml to allow cross-builds via jitpack

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+install:
+   - sbt +publishM2


### PR DESCRIPTION
Without this fix, jitpack only builds against the current scala-version.