### PR TITLE
Fix AnyVal Pickler derivation

### DIFF
--- a/boopickle/shared/src/main/scala/boopickle/PicklerMaterializersImpl.scala
+++ b/boopickle/shared/src/main/scala/boopickle/PicklerMaterializersImpl.scala
@@ -117,7 +117,10 @@ object PicklerMaterializersImpl {
         q"""state.pickle[$fieldTpe](value.${accessor.name})"""
       }
 
-      q"""
+      if (sym.isDerivedValueClass)
+        q"..$pickleFields"
+      else
+        q"""
         val ref = state.identityRefFor(value)
         if(ref.isDefined) {
           state.enc.writeInt(-ref.get)
@@ -142,7 +145,10 @@ object PicklerMaterializersImpl {
         val fieldTpe = accessor.typeSignatureIn(tpe).finalResultType
         q"""state.unpickle[$fieldTpe]"""
       }
-      q"""
+      if (sym.isDerivedValueClass)
+        q"new $tpe(..$unpickledFields)"
+      else
+        q"""
         val ic = state.dec.readInt
         if(ic == 0) {
           val value = new $tpe(..$unpickledFields)

--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val perftestsJS = preventPublication(perftests.js).enablePlugins(WorkbenchP
 
 lazy val perftestsJVM = preventPublication(perftests.jvm)
   .settings(
-    libraryDependencies += "io.circe" %% "circe-jawn" % "0.2.1"
+    libraryDependencies += "io.circe" %% "circe-jawn" % "0.8.0"
   )
   .dependsOn(boopickleJVM)
 


### PR DESCRIPTION
I don't know why existing tests compile. But outside of the project derived `Pickler` for `AnyVal` fails to compile. Because `identityRefFor` accepts `AnyRef`.

Also I bumped `circe-jawn` because there is no `0.2.1` published for `Scala 2.12.x`.