### PR TITLE
Bump circe-jawn

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -185,7 +185,7 @@ lazy val perftestsJS = preventPublication(perftests.js).enablePlugins(WorkbenchP
 
 lazy val perftestsJVM = preventPublication(perftests.jvm)
   .settings(
-    libraryDependencies += "io.circe" %% "circe-jawn" % "0.2.1"
+    libraryDependencies += "io.circe" %% "circe-jawn" % "0.9.2"
   )
   .dependsOn(boopickleJVM)
 


### PR DESCRIPTION
Bump `circe-jawn` to `0.9.2` because there is no `0.2.1` published for `2.12.x`