### PR TITLE
Scala Native support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,10 @@ jdk:
 - openjdk10
 node_js:
 - 8
+before_script:
+  - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -x
 script:
-- sbt ++$TRAVIS_SCALA_VERSION boopickleJVM/test boopickleJS/test shapelessJVM/test shapelessJS/test
+- sbt ++$TRAVIS_SCALA_VERSION boopickleJVM/test boopickleJS/test boopickleNative/test shapelessJVM/test shapelessJS/test shapelessNative/test
 # Tricks to avoid unnecessary cache updates, from
 # http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html
 - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/boopickle/js/src/main/scala/boopickle/ReferenceEquality.scala
+++ b/boopickle/js/src/main/scala/boopickle/ReferenceEquality.scala
@@ -1,0 +1,7 @@
+package boopickle
+
+object ReferenceEquality {
+  @inline def eq(a: AnyRef, b: AnyRef): Boolean  = a eq b
+  @inline def ne(a: AnyRef, b: AnyRef): Boolean  = a ne b
+  @inline def identityHashCode(obj: AnyRef): Int = System.identityHashCode(obj)
+}

--- a/boopickle/jvm/src/main/scala/boopickle/ReferenceEquality.scala
+++ b/boopickle/jvm/src/main/scala/boopickle/ReferenceEquality.scala
@@ -1,0 +1,7 @@
+package boopickle
+
+object ReferenceEquality {
+  @inline def eq(a: AnyRef, b: AnyRef): Boolean  = a eq b
+  @inline def ne(a: AnyRef, b: AnyRef): Boolean  = a ne b
+  @inline def identityHashCode(obj: AnyRef): Int = System.identityHashCode(obj)
+}

--- a/boopickle/native/src/main/scala/boopickle/DefaultByteBufferProvider.scala
+++ b/boopickle/native/src/main/scala/boopickle/DefaultByteBufferProvider.scala
@@ -1,0 +1,5 @@
+package boopickle
+
+object DefaultByteBufferProvider extends DefaultByteBufferProviderFuncs {
+  override def provider = new HeapByteBufferProvider
+}

--- a/boopickle/native/src/main/scala/boopickle/ReferenceEquality.scala
+++ b/boopickle/native/src/main/scala/boopickle/ReferenceEquality.scala
@@ -1,0 +1,7 @@
+package boopickle
+
+object ReferenceEquality {
+  @inline def eq(a: AnyRef, b: AnyRef): Boolean  = a == b
+  @inline def ne(a: AnyRef, b: AnyRef): Boolean  = a != b
+  @inline def identityHashCode(obj: AnyRef): Int = obj.hashCode()
+}

--- a/boopickle/native/src/main/scala/boopickle/StringCodec.scala
+++ b/boopickle/native/src/main/scala/boopickle/StringCodec.scala
@@ -1,0 +1,26 @@
+package boopickle
+
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
+
+object StringCodec extends StringCodecBase {
+  override def decodeUTF8(len: Int, buf: ByteBuffer): String = {
+    val a = new Array[Byte](len)
+    buf.get(a)
+    new String(a, StandardCharsets.UTF_8)
+  }
+
+  override def encodeUTF8(str: String): ByteBuffer = {
+    ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_8))
+  }
+
+  override def decodeUTF16(len: Int, buf: ByteBuffer): String = {
+    val a = new Array[Byte](len)
+    buf.get(a)
+    new String(a, StandardCharsets.UTF_16LE)
+  }
+
+  override def encodeUTF16(str: String): ByteBuffer = {
+    ByteBuffer.wrap(str.getBytes(StandardCharsets.UTF_16LE))
+  }
+}

--- a/boopickle/shared/src/main/scala/boopickle/IdentMap.scala
+++ b/boopickle/shared/src/main/scala/boopickle/IdentMap.scala
@@ -21,7 +21,7 @@ object EmptyIdentMap extends IdentMap {
 
 private[boopickle] final class IdentMap1(o1: AnyRef) extends IdentMap {
   override def apply(obj: AnyRef): Option[Int] = {
-    if (obj eq o1)
+    if (ReferenceEquality.eq(obj, o1))
       Some(2)
     else None
   }
@@ -31,9 +31,9 @@ private[boopickle] final class IdentMap1(o1: AnyRef) extends IdentMap {
 
 private[boopickle] final class IdentMap2(o1: AnyRef, o2: AnyRef) extends IdentMap {
   override def apply(obj: AnyRef): Option[Int] = {
-    if (obj eq o1)
+    if (ReferenceEquality.eq(obj, o1))
       Some(2)
-    else if (obj eq o2)
+    else if (ReferenceEquality.eq(obj, o2))
       Some(3)
     else None
   }
@@ -67,10 +67,10 @@ private[boopickle] final class IdentMap3Plus(o1: AnyRef, o2: AnyRef, o3: AnyRef)
   }
 
   override def apply(obj: AnyRef): Option[Int] = {
-    val hash     = System.identityHashCode(obj)
+    val hash     = ReferenceEquality.identityHashCode(obj)
     val tableIdx = hashIdx(hash)
     var e        = hashTable(tableIdx)
-    while ((e != null) && (e.obj ne obj)) e = e.next
+    while ((e != null) && ReferenceEquality.ne(e.obj, obj)) e = e.next
     if (e == null)
       None
     else
@@ -78,7 +78,7 @@ private[boopickle] final class IdentMap3Plus(o1: AnyRef, o2: AnyRef, o3: AnyRef)
   }
 
   override def updated(obj: AnyRef): IdentMap = {
-    val hash     = System.identityHashCode(obj)
+    val hash     = ReferenceEquality.identityHashCode(obj)
     val tableIdx = hashIdx(hash)
     hashTable(tableIdx) = new Entry(hash, obj, curIdx, hashTable(tableIdx))
     curIdx += 1

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,10 @@ val commonSettings = Seq(
 val nativeSettings = Seq(
   scalaVersion := "2.11.12",
   crossScalaVersions := Seq("2.11.12"),
-  nativeLinkStubs := true
+  nativeLinkStubs := true,
+  // Disable Scaladoc generation because of:
+  // [error] dropping dependency on node with no phase object: mixin
+  Compile / doc / sources := Seq.empty
 )
 
 val releaseSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,15 @@ val commonSettings = Seq(
   Compile / scalacOptions ~= (_ filterNot (_ == "-Ywarn-value-discard")),
   testFrameworks += new TestFramework("utest.runner.Framework"),
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %%% "utest" % "0.6.5" % "test",
+    "com.lihaoyi" %%% "utest" % "0.6.6" % Test,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
   )
+)
+
+val nativeSettings = Seq(
+  scalaVersion := "2.11.12",
+  crossScalaVersions := Seq("2.11.12"),
+  nativeLinkStubs := true
 )
 
 val releaseSettings = Seq(
@@ -90,7 +96,7 @@ def preventPublication(p: Project) =
     packagedArtifacts := Map.empty
   )
 
-lazy val boopickle = crossProject(JSPlatform, JVMPlatform)
+lazy val boopickle = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(commonSettings)
   .settings(releaseSettings)
   .settings(
@@ -98,12 +104,13 @@ lazy val boopickle = crossProject(JSPlatform, JVMPlatform)
   )
   .jsSettings(sourceMapSettings)
   .jvmSettings()
+  .nativeSettings(nativeSettings)
 
 lazy val boopickleJS = boopickle.js
-
 lazy val boopickleJVM = boopickle.jvm
+lazy val boopickleNative = boopickle.native
 
-lazy val shapeless = crossProject(JSPlatform, JVMPlatform)
+lazy val shapeless = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .dependsOn(boopickle)
   .settings(commonSettings)
@@ -116,10 +123,11 @@ lazy val shapeless = crossProject(JSPlatform, JVMPlatform)
   )
   .jsSettings(sourceMapSettings)
   .jvmSettings()
+  .nativeSettings(nativeSettings)
 
 lazy val shapelessJS = shapeless.js
-
 lazy val shapelessJVM = shapeless.jvm
+lazy val shapelessNative = shapeless.native
 
 lazy val generateTuples = taskKey[Unit]("Generates source code for pickling tuples")
 
@@ -166,13 +174,13 @@ lazy val perftests = crossProject(JSPlatform, JVMPlatform)
       "io.circe"          %%% "circe-parser"  % "0.9.2",
       "io.circe"          %%% "circe-generic" % "0.9.2"
     ),
-    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+    addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
   )
   .enablePlugins(JmhPlugin)
   .jsSettings(
     scalaJSOptimizerOptions in (Compile, fullOptJS) ~= { _.withUseClosureCompiler(false) },
     libraryDependencies ++= Seq(
-      "org.scala-js" %%% "scalajs-dom" % "0.9.5",
+      "org.scala-js" %%% "scalajs-dom" % "0.9.6",
       "com.lihaoyi"  %%% "scalatags"   % "0.6.7"
     )
   )
@@ -187,4 +195,4 @@ lazy val perftestsJVM = preventPublication(perftests.jvm)
 
 lazy val booPickleRoot = preventPublication(project.in(file(".")))
   .settings(commonSettings)
-  .aggregate(boopickleJS, boopickleJVM, shapelessJS, shapelessJVM)
+  .aggregate(boopickleJS, boopickleJVM, boopickleNative, shapelessJS, shapelessJVM, shapelessNative)

--- a/doc/Details.md
+++ b/doc/Details.md
@@ -43,11 +43,11 @@ implicit object PersonPickler extends Pickler[Person] {
 }
 ```
 
-This would be very tedious, which is why practically all serialization libraries use either reflection or macros to automate this task. BooPickle
-being fully compatible with Scala.js, reflection is not an option, so macros it is. Programming macros in Scala is quite difficult, because it's a very
-recent addition to the Scala compiler and the documentation tends to be terse and somewhat cryptic. Also many examples found in the net are already
-obsolete or wrong if you use Scala 2.11. Best course of action is to look at existing macro code and try to deduce what's going on. Both
-uPickle and Prickle provided good base for BooPickle's macros.
+This would be very tedious, which is why practically all serialization libraries use either reflection or macros to automate this task. Being fully
+compatible with Scala.js and Scala Native, BooPickle can't use reflection, so it uses macros. Programming macros in Scala is quite difficult, because
+it's a very recent addition to the Scala compiler and the documentation tends to be terse and somewhat cryptic. Also many examples found in the
+net are already obsolete or wrong if you use Scala 2.11. Best course of action is to look at existing macro code and try to deduce what's going on.
+Both uPickle and Prickle provided good base for BooPickle's macros.
 
 The macro-generated picklers are provided by a separate trait to make sure they are the last resort the compiler turns to.
 

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -1,10 +1,10 @@
 # Getting started
 
-Add following dependency declaration to your Scala project 
+Add following dependency declaration to your Scala project:
 
 <pre><code class="lang-scala">"io.suzaku" %% "boopickle" % "{{ book.version }}"</code></pre>
 
-On a Scala.js project the dependency looks like this
+On a Scala.js or a Scala Native project the dependency looks like this:
 
 <pre><code class="lang-scala">"io.suzaku" %%% "boopickle" % "{{ book.version }}"</code></pre>
 
@@ -31,7 +31,7 @@ val helloWorld = Unpickle[Seq[String]].fromBytes(buf)
 
 ## Supported types
 
-BooPickle has built-in support for most of the regular Scala types, including
+BooPickle has built-in support for most of the regular Scala types, including:
 
 - primitives: `Boolean`, `Byte`, `Short`, `Char`, `Int`, `Long`, `Float`, `Double` and `String`
 - common types: `Tuple`s, `Option`, `Either`, `Duration`, `UUID`, `BigInt`, `BigDecimal` and `ByteBuffer`

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,14 +4,14 @@
 [![Build Status](https://travis-ci.org/suzaku-io/boopickle.svg?branch=master)](https://travis-ci.org/suzaku-io/boopickle)
 [![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.13.svg)](http://www.scala-js.org)
 
-BooPickle is the [fastest](http://ochrons.github.io/boopickle-perftest/) and most size efficient serialization (aka pickling) library that works on both Scala
-and [Scala.js](http://www.scala-js.org). It encodes into a binary format instead of the more customary JSON. A binary format brings efficiency 
+BooPickle is the [fastest](http://ochrons.github.io/boopickle-perftest/) and most size efficient serialization (aka pickling) library that works on Scala,
+[Scala.js](http://www.scala-js.org) and [Scala Native](http://www.scala-native.org). It encodes into a binary format instead of the more customary JSON. A binary format brings efficiency 
 gains in both size and speed, at the cost of legibility of the encoded data. BooPickle borrows heavily from both [uPickle](https://github.com/lihaoyi/upickle-pprint)
 and [Prickle](https://github.com/benhutchison/prickle) so special thanks to Li Haoyi and Ben Hutchison for those two great libraries!
 
 ## Features
 
-- Supports both Scala and Scala.js (no reflection!)
+- Supports Scala, Scala.js and Scala Native (no reflection!)
 - Serialization support for all primitives, collections, options, tuples and case classes (including class hierarchies)
 - User-definable custom serializers
 - Transforming serializers to simplify serializing non-case classes

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,13 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.23")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.26")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
+
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.8")
 
 addSbtPlugin("com.lihaoyi" % "workbench" % "0.4.1")
 


### PR DESCRIPTION
Changes to support Scala Native. There is a different behavior of `AnyRef`'s `getClass()` that returns a new instance on every invocation, so I created a file called `ReferenceEquality` to be used in place of `eq`, `ne` and `System.identityHashCode()` with real reference equality on JVM and JS platforms and normal equality on Scala Native. For `DefaultByteBufferProvider` and `StringCodec` I copied the files of JVM platform. Edited the travis script to setup Scala Native environment.