### PR TITLE
Support scala 2.13.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 scala:
 - 2.11.12
 - 2.12.6
+- 2.13.0-RC1
 sudo: false
 jdk:
 - oraclejdk8

--- a/boopickle/jvm/src/test/scala/boopickle/BufferPoolTestsJVM.scala
+++ b/boopickle/jvm/src/test/scala/boopickle/BufferPoolTestsJVM.scala
@@ -7,7 +7,7 @@ import utest._
 object BufferPoolTestsJVM extends TestSuite {
 
   override def tests = Tests {
-    'MultiThread {
+    "MultiThread" - {
       val pool  = BufferPool
       val count = 100000
       def runner = new Runnable {

--- a/boopickle/shared/src/main/scala-2.13+/boopickle/XCompat.scala
+++ b/boopickle/shared/src/main/scala-2.13+/boopickle/XCompat.scala
@@ -1,0 +1,110 @@
+package boopickle
+
+import boopickle.Constants.NullRef
+import scala.collection.Factory
+import scala.language.higherKinds
+
+trait XCompatImplicitPicklers {
+  this: PicklerHelper =>
+
+  implicit def mapPickler[T: P, S: P, V[_, _] <: scala.collection.Map[_, _]](
+      implicit cbf: Factory[(T, S), V[T, S]]): P[V[T, S]] = BasicPicklers.MapPickler[T, S, V]
+  implicit def iterablePickler[T: P, V[_] <: Iterable[_]](implicit cbf: Factory[T, V[T]]): P[V[T]] =
+    BasicPicklers.IterablePickler[T, V]
+}
+
+trait XCompatPicklers {
+  this: PicklerHelper =>
+
+  /**
+    * This pickler works on all collections that derive from Iterable[T] (Vector, Set, List, etc)
+    *
+    * @tparam T type of the values
+    * @tparam V type of the collection
+    * @return
+    */
+  def IterablePickler[T: P, V[_] <: Iterable[_]](implicit cbf: Factory[T, V[T]]): P[V[T]] = new P[V[T]] {
+    override def pickle(iterable: V[T])(implicit state: PickleState): Unit = {
+      if (iterable == null) {
+        state.enc.writeInt(NullRef)
+      } else {
+        // encode length
+        state.enc.writeInt(iterable.size)
+        // encode contents
+        iterable.iterator.asInstanceOf[Iterator[T]].foreach(a => write[T](a))
+      }
+    }
+
+    override def unpickle(implicit state: UnpickleState): V[T] = {
+      state.dec.readInt match {
+        case NullRef =>
+          null.asInstanceOf[V[T]]
+        case 0 =>
+          // empty sequence
+          val res = cbf.newBuilder.result
+          res
+        case len =>
+          val b = cbf.newBuilder
+          b.sizeHint(len)
+          var i = 0
+          while (i < len) {
+            b += read[T]
+            i += 1
+          }
+          val res = b.result
+          res
+      }
+    }
+  }
+
+  /**
+    * Maps require a specific pickler as they have two type parameters.
+    *
+    * @tparam T Type of keys
+    * @tparam S Type of values
+    * @return
+    */
+  def MapPickler[T: P, S: P, V[_, _] <: scala.collection.Map[_, _]](implicit cbf: Factory[(T, S), V[T, S]]): P[V[T, S]] =
+    new P[V[T, S]] {
+      override def pickle(map: V[T, S])(implicit state: PickleState): Unit = {
+        if (map == null) {
+          state.enc.writeInt(NullRef)
+        } else {
+          // encode length
+          state.enc.writeInt(map.size)
+          // encode contents as a sequence
+          val kPickler = implicitly[P[T]]
+          val vPickler = implicitly[P[S]]
+          map.asInstanceOf[scala.collection.Map[T, S]].foreach { kv =>
+            kPickler.pickle(kv._1)(state)
+            vPickler.pickle(kv._2)(state)
+          }
+        }
+      }
+
+      override def unpickle(implicit state: UnpickleState): V[T, S] = {
+        state.dec.readInt match {
+          case NullRef =>
+            null.asInstanceOf[V[T, S]]
+          case 0 =>
+            // empty map
+            val res = cbf.newBuilder.result
+            res
+          case idx if idx < 0 =>
+            state.identityFor[V[T, S]](-idx)
+          case len =>
+            val b = cbf.newBuilder
+            b.sizeHint(len)
+            val kPickler = implicitly[P[T]]
+            val vPickler = implicitly[P[S]]
+            var i        = 0
+            while (i < len) {
+              b += kPickler.unpickle(state) -> vPickler.unpickle(state)
+              i += 1
+            }
+            val res = b.result
+            res
+        }
+      }
+    }
+}

--- a/boopickle/shared/src/main/scala-2.13-/boopickle/XCompat.scala
+++ b/boopickle/shared/src/main/scala-2.13-/boopickle/XCompat.scala
@@ -1,0 +1,114 @@
+package boopickle
+
+import boopickle.Constants.NullRef
+
+import collection.generic.CanBuildFrom
+import scala.collection.generic.CanBuildFrom
+import scala.language.higherKinds
+
+trait XCompatImplicitPicklers {
+  this: PicklerHelper =>
+
+  implicit def mapPickler[T: P, S: P, V[_, _] <: scala.collection.Map[_, _]](
+      implicit cbf: CanBuildFrom[Nothing, (T, S), V[T, S]]): P[V[T, S]] =
+    BasicPicklers.MapPickler[T, S, V]
+  implicit def iterablePickler[T: P, V[_] <: Iterable[_]](implicit cbf: CanBuildFrom[Nothing, T, V[T]]): P[V[T]] =
+    BasicPicklers.IterablePickler[T, V]
+}
+
+trait XCompatPicklers {
+  this: PicklerHelper =>
+
+  /**
+    * This pickler works on all collections that derive from Iterable[T] (Vector, Set, List, etc)
+    *
+    * @tparam T type of the values
+    * @tparam V type of the collection
+    * @return
+    */
+  def IterablePickler[T: P, V[_] <: Iterable[_]](implicit cbf: CanBuildFrom[Nothing, T, V[T]]): P[V[T]] = new P[V[T]] {
+    override def pickle(iterable: V[T])(implicit state: PickleState): Unit = {
+      if (iterable == null) {
+        state.enc.writeInt(NullRef)
+      } else {
+        // encode length
+        state.enc.writeInt(iterable.size)
+        // encode contents
+        iterable.iterator.asInstanceOf[Iterator[T]].foreach(a => write[T](a))
+      }
+    }
+
+    override def unpickle(implicit state: UnpickleState): V[T] = {
+      state.dec.readInt match {
+        case NullRef =>
+          null.asInstanceOf[V[T]]
+        case 0 =>
+          // empty sequence
+          val res = cbf().result()
+          res
+        case len =>
+          val b = cbf()
+          b.sizeHint(len)
+          var i = 0
+          while (i < len) {
+            b += read[T]
+            i += 1
+          }
+          val res = b.result()
+          res
+      }
+    }
+  }
+
+  /**
+    * Maps require a specific pickler as they have two type parameters.
+    *
+    * @tparam T Type of keys
+    * @tparam S Type of values
+    * @return
+    */
+  def MapPickler[T: P, S: P, V[_, _] <: scala.collection.Map[_, _]](
+      implicit cbf: CanBuildFrom[Nothing, (T, S), V[T, S]]): P[V[T, S]] =
+    new P[V[T, S]] {
+      override def pickle(map: V[T, S])(implicit state: PickleState): Unit = {
+        if (map == null) {
+          state.enc.writeInt(NullRef)
+        } else {
+          // encode length
+          state.enc.writeInt(map.size)
+          // encode contents as a sequence
+          val kPickler = implicitly[P[T]]
+          val vPickler = implicitly[P[S]]
+          map.asInstanceOf[scala.collection.Map[T, S]].foreach { kv =>
+            kPickler.pickle(kv._1)(state)
+            vPickler.pickle(kv._2)(state)
+          }
+        }
+      }
+
+      override def unpickle(implicit state: UnpickleState): V[T, S] = {
+        state.dec.readInt match {
+          case NullRef =>
+            null.asInstanceOf[V[T, S]]
+          case 0 =>
+            // empty map
+            val res = cbf().result()
+            res
+          case idx if idx < 0 =>
+            state.identityFor[V[T, S]](-idx)
+          case len =>
+            val b = cbf()
+            b.sizeHint(len)
+            val kPickler = implicitly[P[T]]
+            val vPickler = implicitly[P[S]]
+            var i        = 0
+            while (i < len) {
+              b += kPickler.unpickle(state) -> vPickler.unpickle(state)
+              i += 1
+            }
+            val res = b.result()
+            res
+        }
+      }
+    }
+}

--- a/boopickle/shared/src/main/scala/boopickle/BufferProvider.scala
+++ b/boopickle/shared/src/main/scala/boopickle/BufferProvider.scala
@@ -93,7 +93,7 @@ class HeapByteBufferProvider extends ByteBufferProvider {
       val comb    = allocate(bufList.map(_.limit()).sum)
       bufList.foreach { buf =>
         // use fast array copy
-        scala.compat.Platform.arraycopy(buf.array, buf.arrayOffset, comb.array, comb.position(), buf.limit())
+        java.lang.System.arraycopy(buf.array, buf.arrayOffset, comb.array, comb.position(), buf.limit())
         comb.position(comb.position() + buf.limit())
         // release to the pool
         pool.release(buf)

--- a/boopickle/shared/src/main/scala/boopickle/Default.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Default.scala
@@ -3,14 +3,13 @@ package boopickle
 import java.nio.{ByteBuffer, ByteOrder}
 import java.util.UUID
 
-import scala.collection.generic.CanBuildFrom
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.language.experimental.macros
 import scala.language.higherKinds
 import scala.reflect.ClassTag
 import scala.util.Try
 
-trait BasicImplicitPicklers extends PicklerHelper {
+trait BasicImplicitPicklers extends PicklerHelper with XCompatImplicitPicklers {
   implicit def unitPickler: ConstPickler[Unit]  = BasicPicklers.UnitPickler
   implicit def booleanPickler: P[Boolean]       = BasicPicklers.BooleanPickler
   implicit def bytePickler: P[Byte]             = BasicPicklers.BytePickler
@@ -37,10 +36,6 @@ trait BasicImplicitPicklers extends PicklerHelper {
   implicit def leftPickler[T: P, S: P]: P[Left[T, S]]     = BasicPicklers.LeftPickler[T, S]
   implicit def rightPickler[T: P, S: P]: P[Right[T, S]]   = BasicPicklers.RightPickler[T, S]
   implicit def arrayPickler[T: P: ClassTag]: P[Array[T]]  = BasicPicklers.ArrayPickler[T]
-  implicit def mapPickler[T: P, S: P, V[_, _] <: scala.collection.Map[_, _]](
-      implicit cbf: CanBuildFrom[Nothing, (T, S), V[T, S]]): P[V[T, S]] = BasicPicklers.MapPickler[T, S, V]
-  implicit def iterablePickler[T: P, V[_] <: Iterable[_]](implicit cbf: CanBuildFrom[Nothing, T, V[T]]): P[V[T]] =
-    BasicPicklers.IterablePickler[T, V]
 }
 
 trait TransformPicklers {

--- a/boopickle/shared/src/main/scala/boopickle/Pickler.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Pickler.scala
@@ -49,7 +49,7 @@ trait PicklerHelper {
   protected def read[A](implicit state: UnpickleState, u: P[A]): A = u.unpickle
 }
 
-object BasicPicklers extends PicklerHelper {
+object BasicPicklers extends PicklerHelper with XCompatPicklers {
 
   import Constants._
 
@@ -291,49 +291,6 @@ object BasicPicklers extends PicklerHelper {
 
   def RightPickler[T: P, S: P]: P[Right[T, S]] = EitherPickler[T, S].asInstanceOf[P[Right[T, S]]]
 
-  import collection.generic.CanBuildFrom
-
-  /**
-    * This pickler works on all collections that derive from Iterable[T] (Vector, Set, List, etc)
-    *
-    * @tparam T type of the values
-    * @tparam V type of the collection
-    * @return
-    */
-  def IterablePickler[T: P, V[_] <: Iterable[_]](implicit cbf: CanBuildFrom[Nothing, T, V[T]]): P[V[T]] = new P[V[T]] {
-    override def pickle(iterable: V[T])(implicit state: PickleState): Unit = {
-      if (iterable == null) {
-        state.enc.writeInt(NullRef)
-      } else {
-        // encode length
-        state.enc.writeInt(iterable.size)
-        // encode contents
-        iterable.iterator.asInstanceOf[Iterator[T]].foreach(a => write[T](a))
-      }
-    }
-
-    override def unpickle(implicit state: UnpickleState): V[T] = {
-      state.dec.readInt match {
-        case NullRef =>
-          null.asInstanceOf[V[T]]
-        case 0 =>
-          // empty sequence
-          val res = cbf().result()
-          res
-        case len =>
-          val b = cbf()
-          b.sizeHint(len)
-          var i = 0
-          while (i < len) {
-            b += read[T]
-            i += 1
-          }
-          val res = b.result()
-          res
-      }
-    }
-  }
-
   /**
     * Specific pickler for Arrays
     *
@@ -398,58 +355,6 @@ object BasicPicklers extends PicklerHelper {
       }
     }
   }
-
-  /**
-    * Maps require a specific pickler as they have two type parameters.
-    *
-    * @tparam T Type of keys
-    * @tparam S Type of values
-    * @return
-    */
-  def MapPickler[T: P, S: P, V[_, _] <: scala.collection.Map[_, _]](
-      implicit cbf: CanBuildFrom[Nothing, (T, S), V[T, S]]): P[V[T, S]] =
-    new P[V[T, S]] {
-      override def pickle(map: V[T, S])(implicit state: PickleState): Unit = {
-        if (map == null) {
-          state.enc.writeInt(NullRef)
-        } else {
-          // encode length
-          state.enc.writeInt(map.size)
-          // encode contents as a sequence
-          val kPickler = implicitly[P[T]]
-          val vPickler = implicitly[P[S]]
-          map.asInstanceOf[scala.collection.Map[T, S]].foreach { kv =>
-            kPickler.pickle(kv._1)(state)
-            vPickler.pickle(kv._2)(state)
-          }
-        }
-      }
-
-      override def unpickle(implicit state: UnpickleState): V[T, S] = {
-        state.dec.readInt match {
-          case NullRef =>
-            null.asInstanceOf[V[T, S]]
-          case 0 =>
-            // empty map
-            val res = cbf().result()
-            res
-          case idx if idx < 0 =>
-            state.identityFor[V[T, S]](-idx)
-          case len =>
-            val b = cbf()
-            b.sizeHint(len)
-            val kPickler = implicitly[P[T]]
-            val vPickler = implicitly[P[S]]
-            var i        = 0
-            while (i < len) {
-              b += kPickler.unpickle(state) -> vPickler.unpickle(state)
-              i += 1
-            }
-            val res = b.result()
-            res
-        }
-      }
-    }
 }
 
 /**

--- a/boopickle/shared/src/test/scala/boopickle/BufferProviderTests.scala
+++ b/boopickle/shared/src/test/scala/boopickle/BufferProviderTests.scala
@@ -11,7 +11,7 @@ import boopickle.Default._
 object BufferProviderTests extends TestSuite {
 
   override def tests = Tests {
-    'asByteBuffersProperOrder {
+    "asByteBuffersProperOrder" - {
 
       val input: Seq[Banana] = Iterator.tabulate(1000)(_ => Banana(Random.nextDouble)).toVector
       val bbs                = Pickle.intoByteBuffers(input)

--- a/boopickle/shared/src/test/scala/boopickle/CodecTests.scala
+++ b/boopickle/shared/src/test/scala/boopickle/CodecTests.scala
@@ -40,12 +40,12 @@ object CodecTests extends TestSuite {
   }
 
   override def tests = Tests {
-    'Byte - {
+    "Byte" - {
       val data = Seq[Byte](0, 1, -128, 127, -1)
       runCodec[Byte](data, (e, x) => { e.writeByte(x); () }, (d, x) => d.readByte == x)
     }
 
-    'Int - {
+    "Int" - {
       val data = Seq(
         0,
         1,
@@ -73,7 +73,7 @@ object CodecTests extends TestSuite {
       runCodec[Int](data, (e, x) => { e.writeInt(x); () }, (d, x) => d.readInt == x)
     }
 
-    'Long - {
+    "Long" - {
       val data = Seq[Long](0,
                            1,
                            -1,
@@ -93,29 +93,29 @@ object CodecTests extends TestSuite {
       runCodec[Long](data, (e, x) => { e.writeLong(x); () }, (d, x) => d.readLong == x)
     }
 
-    'Float - {
+    "Float" - {
       val data =
         Seq[Float](0.0f, 1.0f, -0.5f, Float.MaxValue, Float.MinValue, Float.NegativeInfinity, Float.PositiveInfinity)
       runCodec[Float](data, (e, x) => { e.writeFloat(x); () }, (d, x) => d.readFloat == x)
     }
 
-    'Double - {
+    "Double" - {
       val data =
         Seq[Double](0.0, 1.0, -0.5, Double.MaxValue, Double.MinValue, Double.NegativeInfinity, Double.PositiveInfinity)
       runCodec[Double](data, (e, x) => { e.writeDouble(x); () }, (d, x) => d.readDouble == x)
     }
 
-    'Char - {
+    "Char" - {
       val data = Seq[Char](' ', 'A', 'Ö', '叉', '€')
       runCodec[Char](data, (e, x) => { e.writeChar(x); () }, (d, x) => d.readChar == x)
     }
 
-    'String - {
+    "String" - {
       val data = Seq[String]("", "A", "叉", "Normal String", "Arabic ڞ", "Complex \uD840\uDC00\uD841\uDDA7")
       runCodec[String](data, (e, x) => { e.writeString(x); () }, (d, x) => d.readString == x)
     }
 
-    'ByteBuffer - {
+    "ByteBuffer" - {
       val bb = ByteBuffer.allocateDirect(256)
       for (i <- 0 until 256) bb.put(i.toByte)
       bb.flip
@@ -127,28 +127,28 @@ object CodecTests extends TestSuite {
       assert(y.compareTo(bb) == 0)
     }
 
-    'ByteArray - {
+    "ByteArray" - {
       val ba = Seq(Array[Byte](0, 127, -128, -1, 1), Array[Byte]())
       runCodec[Array[Byte]](ba, (e, x) => { e.writeByteArray(x); () }, (d, x) => d.readByteArray.sameElements(x))
     }
 
-    'IntArray - {
+    "IntArray" - {
       val ba = Seq(Array[Int](0, Int.MaxValue, Int.MinValue, -1, 1, 256, 65536), Array[Int]())
       runCodec[Array[Int]](ba, (e, x) => { e.writeIntArray(x); () }, (d, x) => d.readIntArray.sameElements(x))
     }
 
-    'FloatArray - {
+    "FloatArray" - {
       val ba = Seq(Array[Float](0, Float.MaxValue, Float.MinValue, -1, 1, 256.0f, 65536.0f), Array[Float]())
       runCodec[Array[Float]](ba, (e, x) => { e.writeFloatArray(x); () }, (d, x) => d.readFloatArray.sameElements(x))
     }
 
-    'DoubleArray - {
+    "DoubleArray" - {
       val ba = Seq(Array[Double](0, Double.MaxValue, Double.MinValue, -1, 1, 256.0, 65536.0), Array[Double]())
       runCodec[Array[Double]](ba, (e, x) => { e.writeDoubleArray(x); () }, (d, x) => d.readDoubleArray.sameElements(x))
     }
 
-    'StringEncoding - {
-      'all {
+    "StringEncoding" - {
+      "all" - {
         val cp    = Array.tabulate[Char](65536)(i => i.toChar)
         val str   = new String(cp)
         val codec = new StringCodecFast {}
@@ -162,7 +162,7 @@ object CodecTests extends TestSuite {
           i += 1
         }
       }
-      'unicode {
+      "unicode" - {
         val str   = "\u0c64\u866f\u6a55\ufffd"
         val codec = new StringCodecFast {}
         val bb    = ByteBuffer.allocate(str.length * 3)

--- a/boopickle/shared/src/test/scala/boopickle/IdentMapTests.scala
+++ b/boopickle/shared/src/test/scala/boopickle/IdentMapTests.scala
@@ -5,18 +5,18 @@ import utest._
 
 object IdentMapTests extends TestSuite {
   override def tests = Tests {
-    'IdentMap - {
-      'empty {
+    "IdentMap" - {
+      "empty" - {
         val m = IdentMap.empty
         assert(m("test").isEmpty)
       }
-      'single {
+      "single" - {
         val test = Option(42)
         val m    = EmptyIdentMap.updated(test)
         val x    = m(test)
         assert(x.contains(2))
       }
-      'hash {
+      "hash" - {
         val objs = for (i <- 0 until 60) yield Option(i)
         var m    = IdentMap.empty
         objs.tail.foreach(o => m = m.updated(o))
@@ -31,13 +31,13 @@ object IdentMapTests extends TestSuite {
         println(tableSize)
         assert(tableSize.forall(s => s >= 0 && s < 8))
       }
-      'big {
+      "big" - {
         val objs = for (i <- 0 until 1000) yield s"id$i"
         var m    = IdentMap.empty
         objs.foreach(o => m = m.updated(o))
         assert(m(objs(500)).contains(502))
       }
-      'huge {
+      "huge" - {
         val objs = for (i <- 0 until 16384) yield s"id$i"
         var m    = IdentMap.empty
         objs.foreach(o => m = m.updated(o))

--- a/boopickle/shared/src/test/scala/external/CompositePickleTests.scala
+++ b/boopickle/shared/src/test/scala/external/CompositePickleTests.scala
@@ -62,7 +62,7 @@ final case class OwnerAttribute(owner: String, parent: Element) extends Attribut
 
 object CompositePickleTests extends TestSuite {
   override def tests = Tests {
-    'CaseClassHierarchySeq {
+    "CaseClassHierarchySeq" - {
       implicit val fruitPickler =
         compositePickler[Fruit].addConcreteType[Banana].addConcreteType[Kiwi].addConcreteType[Carambola]
 
@@ -71,7 +71,7 @@ object CompositePickleTests extends TestSuite {
       val u                  = Unpickle[Seq[Fruit]].fromBytes(bb)
       assert(u == fruits)
     }
-    'CaseClassHierarchy {
+    "CaseClassHierarchy" - {
       implicit val fruitPickler =
         compositePickler[Fruit].addConcreteType[Banana].addConcreteType[Kiwi].addConcreteType[Carambola]
 
@@ -86,7 +86,7 @@ object CompositePickleTests extends TestSuite {
       val bf       = Pickle.intoBytes(f)
       assert(Unpickle[Fruit].fromBytes(bf) == f) // This produces a Fruit
     }
-    'CaseObjects {
+    "CaseObjects" - {
       implicit val errorPickler =
         compositePickler[Error]
           .addConcreteType[InvalidName.type]
@@ -97,27 +97,27 @@ object CompositePickleTests extends TestSuite {
       val u                          = Unpickle[Map[Error, String]].fromBytes(bb)
       assert(u == errors)
     }
-    'Recursive {
+    "Recursive" - {
       val tree: Tree = Node(1, Seq(Node(2, Seq(Leaf, Node(3, Seq(Leaf, Leaf)), Node(5, Seq(Leaf, Leaf))))))
       val bb         = Pickle.intoBytes(tree)
       val u          = Unpickle[Tree].fromBytes(bb)
       assert(u == tree)
     }
-    'Complex {
+    "Complex" - {
       val doc        = WordDocument("Testing")
       val q: Element = OwnerAttribute("me", doc)
       val bb         = Pickle.intoBytes(q)
       val u          = Unpickle[Element].fromBytes(bb)
       assert(u == q)
     }
-    'Transformers {
+    "Transformers" - {
       implicit val datePickler = transformPickler((t: Long) => new java.util.Date(t))(_.getTime)
       val date                 = new java.util.Date()
       val bb                   = Pickle.intoBytes(date)
       val d                    = Unpickle[java.util.Date].fromBytes(bb)
       assert(d == date)
     }
-    'Exceptions {
+    "Exceptions" - {
       implicit val exPickler = exceptionPickler
 
       val exs: Seq[Throwable] = Seq(
@@ -129,7 +129,7 @@ object CompositePickleTests extends TestSuite {
       val e  = Unpickle[Seq[Throwable]].fromBytes(bb)
       assert(e.zip(exs).forall(x => x._1.getMessage == x._2.getMessage && x._1.getClass == x._2.getClass))
     }
-    'AddClassTwice {
+    "AddClassTwice" - {
       intercept[IllegalArgumentException] {
         compositePickler[Fruit].addConcreteType[Banana].addConcreteType[Banana]
       }

--- a/boopickle/shared/src/test/scala/external/DefaultBasicTests.scala
+++ b/boopickle/shared/src/test/scala/external/DefaultBasicTests.scala
@@ -31,7 +31,7 @@ object DefaultBasicTests extends TestSuite {
   }
 
   override def tests = Tests {
-    'Trait {
+    "Trait" - {
       val t: Seq[MyTrait] = Seq(TT1(5), TT2("five", TT2("six", new TT3(42, "fortytwo"))))
       val bb              = Pickle.intoBytes(t)
       val u               = Unpickle[Seq[MyTrait]].fromBytes(bb)

--- a/boopickle/shared/src/test/scala/external/MacroPickleTests.scala
+++ b/boopickle/shared/src/test/scala/external/MacroPickleTests.scala
@@ -71,13 +71,13 @@ object MacroPickleTests extends TestSuite {
   override def tests = Tests {
     // must import pickler from the companion object, otherwise scalac will try to use a macro to generate it
     import MyTrait._
-    'CaseClasses - {
-      'Case1 {
+    "CaseClasses" - {
+      "Case1" - {
         val bb = Pickle.intoBytes(Test1(5, "Hello!"))
         assert(bb.limit() == 1 + 1 + 7)
         assert(Unpickle[Test1].fromBytes(bb) == Test1(5, "Hello!"))
       }
-      'SeqCase {
+      "SeqCase" - {
         implicit def pstate                              = new PickleState(new EncoderSize, true)
         implicit def ustate: ByteBuffer => UnpickleState = b => new UnpickleState(new DecoderSize(b), true)
         val t                                            = Test1(99, "Hello!")
@@ -87,90 +87,90 @@ object MacroPickleTests extends TestSuite {
         val u = Unpickle[Seq[Test1]].fromBytes(bb)
         assert(u == s)
       }
-      'Recursive {
+      "Recursive" - {
         val t  = List(Test2(1, Some(Test2(2, Some(Test2(3, None))))))
         val bb = Pickle.intoBytes(t)
         assert(bb.limit() == 13)
         val u = Unpickle[List[Test2]].fromBytes(bb)
         assert(u == t)
       }
-      'CaseObject {
+      "CaseObject" - {
         val bb = Pickle.intoBytes(TestO)
         // yea, pickling a case object takes no space at all :)
         assert(bb.limit() == 0)
         val u = Unpickle[TestO.type].fromBytes(bb)
         assert(u == TestO)
       }
-      'Trait {
+      "Trait" - {
         val t: Seq[MyTrait] = Seq(TT1(5), TT2("five", TT2("six", new TT3(42, "fortytwo"))))
         val bb              = Pickle.intoBytes(t)
         val u               = Unpickle[Seq[MyTrait]].fromBytes(bb)
         assert(u == t)
       }
-      'TraitToo {
+      "TraitToo" - {
         // the same test code twice, to check that additional .class files are not generated for the MyTrait pickler
         val t: Seq[MyTrait] = Seq(TT1(5), TT2("five", TT2("six", new TT3(42, "fortytwo"))))
         val bb              = Pickle.intoBytes(t)
         val u               = Unpickle[Seq[MyTrait]].fromBytes(bb)
         assert(u == t)
       }
-      'AbstractClass {
+      "AbstractClass" - {
         val t: Seq[AClass] = Seq(AB(5), AB(2))
         val bb             = Pickle.intoBytes(t)
         val u              = Unpickle[Seq[AClass]].fromBytes(bb)
         assert(u == t)
       }
-      'AbstractClass2 {
+      "AbstractClass2" - {
         val t: Seq[Version] = Seq(V1, V2)
         val bytes           = Pickle.intoBytes(t)
         val u               = Unpickle[Seq[Version]].fromBytes(bytes)
         assert(u == t)
       }
-      'CaseTupleList {
+      "CaseTupleList" - {
         // this won't compile due to "diverging implicits"
         // val x = A(List(B(List(Tuple2(2.0, 1.0)))))
         // val bb = Pickle.intoBytes(x)
         // val u = Unpickle[A].fromBytes(bb)
         // assert(x == u)
       }
-      'CaseTupleList2 {
+      "CaseTupleList2" - {
         implicit val bPickler = generatePickler[B]
         val x                 = A(List(B(List((2.0, 3.0)))))
         val bb                = Pickle.intoBytes(x)
         val u                 = Unpickle[A].fromBytes(bb)
         assert(x == u)
       }
-      'CaseTupleList3 {
+      "CaseTupleList3" - {
         val x  = List(B(List((2.0, 3.0))))
         val bb = Pickle.intoBytes(x)
         val u  = Unpickle[List[B]].fromBytes(bb)
         assert(x == u)
       }
-      'CaseGenericTraitAndCaseclass {
+      "CaseGenericTraitAndCaseclass" - {
         val x: A1Trait[Int] = A1[Int](2)
         val bb              = Pickle.intoBytes(x)
         val u               = Unpickle[A1Trait[Int]].fromBytes(bb)
         assert(x == u)
       }
-      'CaseGenericTraitAndCaseclass2 {
+      "CaseGenericTraitAndCaseclass2" - {
         val x: A1Trait[Double] = A1[Double](2.0)
         val bb                 = Pickle.intoBytes(x)
         val u                  = Unpickle[A1Trait[Double]].fromBytes(bb)
         assert(x == u)
       }
-      'ValueClass {
+      "ValueClass" - {
         val x: ValueClass = ValueClass(3)
         val bb            = Pickle.intoBytes(x)
         val u             = Unpickle[ValueClass].fromBytes(bb)
         assert(x == u)
       }
-      'TraitAndValueClass {
+      "TraitAndValueClass" - {
         val x: ValueTrait[Int] = new ValueTraitClass[Int](3)
         val bb                 = Pickle.intoBytes(x)
         val u                  = Unpickle[ValueTrait[Int]].fromBytes(bb)
         assert(x == u)
       }
-      'MultipleGenerics {
+      "MultipleGenerics" - {
         val x: MultiT[Int, Double, String] = Multi[Int, Double](1, 2.0)
         val bb                             = Pickle.intoBytes(x)
         val u                              = Unpickle[MultiT[Int, Double, String]].fromBytes(bb)

--- a/boopickle/shared/src/test/scala/external/PerfTests.scala
+++ b/boopickle/shared/src/test/scala/external/PerfTests.scala
@@ -8,7 +8,7 @@ import utest._
 
 object PerfTests extends TestSuite {
   def tests = Tests {
-    'Performance - {
+    "Performance" - {
       case class Test(i: Int, s: String)
       // generate data
       val template = (0 until 500).map(i => Test(i, (i / 2).toString * 20))
@@ -34,12 +34,12 @@ object PerfTests extends TestSuite {
         println(s"Data size ${bb.capacity()}")
         assert(uData == data)
       }
-      'Deduplication {
+      "Deduplication" - {
         dedupTest("With dedup",
                   new PickleState(new EncoderSize, true, true),
                   bb => new UnpickleState(new DecoderSize(bb), true, true))
       }
-      'NoDeduplication {
+      "NoDeduplication" - {
         dedupTest("Without dedup",
                   new PickleState(new EncoderSize, false, false),
                   bb => new UnpickleState(new DecoderSize(bb), false, false))

--- a/boopickle/shared/src/test/scala/external/PickleTests.scala
+++ b/boopickle/shared/src/test/scala/external/PickleTests.scala
@@ -526,7 +526,9 @@ object PickleTests extends TestSuite {
         'arrayOfArray {
           val bb = Pickle.intoBytes(Array(Array(0, 0, 0), Array(1, 1, 1)))
           assert(bb.limit() == 4 + 7 + 7)
-          assert(Unpickle[Array[Array[Int]]].fromBytes(bb).deep == Array(Array(0, 0, 0), Array(1, 1, 1)).deep)
+          assert(
+            java.util.Arrays.deepEquals(Unpickle[Array[Array[Int]]].fromBytes(bb).asInstanceOf[Array[Object]],
+                                        Array(Array(0, 0, 0), Array(1, 1, 1)).asInstanceOf[Array[Object]]))
         }
       }
       'ByteBuffer - {
@@ -1108,7 +1110,9 @@ object PickleTests extends TestSuite {
         'arrayOfArray {
           val bb = Pickle.intoBytes(Array(Array(0, 0, 0), Array(1, 1, 1)))
           assert(bb.limit() == 4 + 4 + 4 * 3 + 4 + 4 * 3)
-          assert(Unpickle[Array[Array[Int]]].fromBytes(bb).deep == Array(Array(0, 0, 0), Array(1, 1, 1)).deep)
+          assert(
+            java.util.Arrays.deepEquals(Unpickle[Array[Array[Int]]].fromBytes(bb).asInstanceOf[Array[Object]],
+                                        Array(Array(0, 0, 0), Array(1, 1, 1)).asInstanceOf[Array[Object]]))
         }
       }
       'ByteBuffer - {

--- a/boopickle/shared/src/test/scala/external/PickleTests.scala
+++ b/boopickle/shared/src/test/scala/external/PickleTests.scala
@@ -30,206 +30,206 @@ object PickleTests extends TestSuite {
   }
 
   def tests = Tests {
-    'sizeCodec - {
+    "sizeCodec" - {
       implicit def pstate = new PickleState(new EncoderSize)
       implicit def ustate = (b: ByteBuffer) => new UnpickleState(new DecoderSize(b))
-      'Boolean - {
-        'true {
+      "Boolean" - {
+        "true" - {
           val bb = Pickle.intoBytes(true)
           assert(bb.limit() == 1)
           assert(Unpickle[Boolean].fromBytes(bb))
         }
-        'false {
+        "false" - {
           val bb = Pickle.intoBytes(false)
           assert(bb.limit() == 1)
           assert(!Unpickle[Boolean].fromBytes(bb))
         }
       }
-      'Byte - {
-        'zero {
+      "Byte" - {
+        "zero" - {
           val bb = Pickle.intoBytes(0.toByte)
           assert(bb.limit() == 1)
           assert(Unpickle[Byte].fromBytes(bb) == 0)
         }
-        'positive {
+        "positive" - {
           val bb = Pickle.intoBytes(50.toByte)
           assert(bb.limit() == 1)
           assert(Unpickle[Byte].fromBytes(bb) == 50)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-1.toByte)
           assert(bb.limit() == 1)
           assert(Unpickle[Byte].fromBytes(bb) == -1)
         }
       }
-      'Short - {
-        'zero {
+      "Short" - {
+        "zero" - {
           val bb = Pickle.intoBytes(0.toShort)
           assert(bb.limit() == 2)
           assert(Unpickle[Short].fromBytes(bb) == 0)
         }
-        'positive {
+        "positive" - {
           val bb = Pickle.intoBytes(0x4000.toShort)
           assert(bb.limit() == 2)
           assert(Unpickle[Short].fromBytes(bb) == 0x4000)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-1.toShort)
           assert(bb.limit() == 2)
           assert(Unpickle[Short].fromBytes(bb) == -1)
         }
       }
-      'Int - {
-        'zero {
+      "Int" - {
+        "zero" - {
           val bb = Pickle.intoBytes(0)
           assert(bb.limit() == 1)
           assert(Unpickle[Int].fromBytes(bb) == 0)
         }
-        'positive {
+        "positive" - {
           val bb = Pickle.intoBytes(1024)
           assert(bb.limit() == 2)
           assert(Unpickle[Int].fromBytes(bb) == 1024)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-1048577)
           assert(bb.limit() == 4)
           assert(Unpickle[Int].fromBytes(bb) == -1048577)
         }
-        'max {
+        "max" - {
           val bb = Pickle.intoBytes(Int.MaxValue)
           assert(bb.limit() == 5)
           assert(Unpickle[Int].fromBytes(bb) == Int.MaxValue)
         }
-        'min {
+        "min" - {
           val bb = Pickle.intoBytes(Int.MinValue)
           assert(bb.limit() == 5)
           assert(Unpickle[Int].fromBytes(bb) == Int.MinValue)
         }
       }
-      'Long - {
-        'positive {
+      "Long" - {
+        "positive" - {
           val bb = Pickle.intoBytes(1024L * 1024L * 1024L * 1024L)
           assert(bb.limit() == 9)
           assert(Unpickle[Long].fromBytes(bb) == 1024L * 1024L * 1024L * 1024L)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-1024L * 1024L * 1024L * 1024L)
           assert(bb.limit() == 9)
           assert(Unpickle[Long].fromBytes(bb) == -1024L * 1024L * 1024L * 1024L)
         }
-        'max {
+        "max" - {
           val bb = Pickle.intoBytes(Long.MaxValue)
           assert(bb.limit() == 9)
           assert(Unpickle[Long].fromBytes(bb) == Long.MaxValue)
         }
-        'min {
+        "min" - {
           val bb = Pickle.intoBytes(Long.MinValue)
           assert(bb.limit() == 9)
           assert(Unpickle[Long].fromBytes(bb) == Long.MinValue)
         }
       }
-      'Float - {
-        'positive {
+      "Float" - {
+        "positive" - {
           val bb = Pickle.intoBytes(0.185f)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == 0.185f)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-0.185f)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == -0.185f)
         }
-        'max {
+        "max" - {
           val bb = Pickle.intoBytes(Float.MaxValue)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == Float.MaxValue)
         }
-        'min {
+        "min" - {
           val bb = Pickle.intoBytes(Float.MinValue)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == Float.MinValue)
         }
-        'infinity {
+        "infinity" - {
           val bb = Pickle.intoBytes(Float.PositiveInfinity)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == Float.PositiveInfinity)
         }
       }
-      'Double - {
-        'positive {
+      "Double" - {
+        "positive" - {
           val bb = Pickle.intoBytes(math.Pi)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == math.Pi)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-math.Pi)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == -math.Pi)
         }
-        'max {
+        "max" - {
           val bb = Pickle.intoBytes(Double.MaxValue)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == Double.MaxValue)
         }
-        'min {
+        "min" - {
           val bb = Pickle.intoBytes(Double.MinValue)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == Double.MinValue)
         }
-        'infinity {
+        "infinity" - {
           val bb = Pickle.intoBytes(Double.PositiveInfinity)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == Double.PositiveInfinity)
         }
       }
-      'BigInt - {
-        'zero {
+      "BigInt" - {
+        "zero" - {
           val bb = Pickle.intoBytes(BigInt(0))
           assert(bb.limit() == 5)
           val bi = Unpickle[BigInt].fromBytes(bb)
           assert(bi == BigInt(0))
         }
-        'positive {
+        "positive" - {
           val value = BigInt("3031082301820398102312310273912739712397")
           val bb    = Pickle.intoBytes(value)
           assert(bb.limit() == value.toByteArray.length + 4)
           assert(Unpickle[BigInt].fromBytes(bb) == value)
         }
-        'negative {
+        "negative" - {
           val value = BigInt("-3031082301820398102312310273912739712397")
           val bb    = Pickle.intoBytes(value)
           assert(bb.limit() == value.toByteArray.length + 4)
           assert(Unpickle[BigInt].fromBytes(bb) == value)
         }
       }
-      'BigDecimal - {
-        'zero {
+      "BigDecimal" - {
+        "zero" - {
           val bb = Pickle.intoBytes(BigDecimal(0))
           assert(bb.limit() == 6)
           assert(Unpickle[BigDecimal].fromBytes(bb) == BigDecimal(0))
         }
-        'positive {
+        "positive" - {
           val value         = BigDecimal("3031082301820398102312310273912739712397.420348203423429374928374")
           val bb            = Pickle.intoBytes(value)
           val expectedLimit = value.underlying.unscaledValue.toByteArray.length + 4 + 1
           assert(bb.limit() == expectedLimit)
           assert(Unpickle[BigDecimal].fromBytes(bb) == value)
         }
-        'positiveZeroScale {
+        "positiveZeroScale" - {
           val value         = BigDecimal("3031082301820398102312310273912739712397420348203423429374928374")
           val bb            = Pickle.intoBytes(value)
           val expectedLimit = value.underlying.unscaledValue.toByteArray.length + 4 + 1
           assert(bb.limit() == expectedLimit)
           assert(Unpickle[BigDecimal].fromBytes(bb) == value)
         }
-        'negativeScale {
+        "negativeScale" - {
           val value         = BigDecimal("-3031082301820398102312310273912739712397.420348203423429374928374")
           val bb            = Pickle.intoBytes(value)
           val expectedLimit = value.underlying.unscaledValue.toByteArray.length + 4 + 1
           assert(bb.limit() == expectedLimit)
           assert(Unpickle[BigDecimal].fromBytes(bb) == value)
         }
-        'negativeZeroScale {
+        "negativeZeroScale" - {
           val value         = BigDecimal("-3031082301820398102312310273912739712397420348203423429374928374")
           val bb            = Pickle.intoBytes(value)
           val expectedLimit = value.underlying.unscaledValue.toByteArray.length + 4 + 1
@@ -237,78 +237,78 @@ object PickleTests extends TestSuite {
           assert(Unpickle[BigDecimal].fromBytes(bb) == value)
         }
       }
-      'String - {
-        'null {
+      "String" - {
+        "null" - {
           val str: String = null
           val bb          = Pickle.intoBytes(str)
           assert(bb.limit() == 2)
           assert(Unpickle[String].fromBytes(bb) == null)
         }
-        'empty {
+        "empty" - {
           val bb = Pickle.intoBytes("")
           assert(bb.limit() == 1)
           assert(Unpickle[String].fromBytes(bb) == "")
         }
-        'normal {
+        "normal" - {
           val bb = Pickle.intoBytes("normal")
           assert(bb.limit() == 1 + 6)
           val s = Unpickle[String].fromBytes(bb)
           assert(s == "normal")
         }
-        'unicode1 {
+        "unicode1" - {
           val bb = Pickle.intoBytes("“Life”")
           assert(bb.limit() == 9)
           val s = Unpickle[String].fromBytes(bb)
           assert(s == "“Life”")
         }
-        'unicode2 {
+        "unicode2" - {
           val bb = Pickle.intoBytes("\uD834\uDF06泡菜")
           assert(bb.limit() == 1 + 3 * 4)
           val s = Unpickle[String].fromBytes(bb)
           assert(s == "\uD834\uDF06泡菜")
         }
-        'numeric {
+        "numeric" - {
           val bb = Pickle.intoBytes("100")
           assert(bb.limit() == 4)
           assert(Unpickle[String].fromBytes(bb) == "100")
         }
-        'numericSmall {
+        "numericSmall" - {
           val bb = Pickle.intoBytes("5")
           assert(Unpickle[String].fromBytes(bb) == "5")
         }
-        'numericLarge {
+        "numericLarge" - {
           val bb = Pickle.intoBytes("-10000000000")
           assert(bb.limit() == 13)
           assert(Unpickle[String].fromBytes(bb) == "-10000000000")
         }
-        'numeric20 {
+        "numeric20" - {
           val bb = Pickle.intoBytes("45248643522829592471")
           // assert(bb.limit() == 1 + 8)
           assert(Unpickle[String].fromBytes(bb) == "45248643522829592471")
         }
-        'numericStart {
+        "numericStart" - {
           val bb = Pickle.intoBytes("100x")
           assert(bb.limit() == 1 + 4)
           assert(Unpickle[String].fromBytes(bb) == "100x")
         }
-        'numericZeros {
+        "numericZeros" - {
           val bb = Pickle.intoBytes("0100")
           assert(bb.limit() == 1 + 4)
           assert(Unpickle[String].fromBytes(bb) == "0100")
         }
-        'uuid {
+        "uuid" - {
           val uuidStr = UUID.randomUUID().toString
           val bb      = Pickle.intoBytes(uuidStr)
           assert(bb.limit() == 37)
           assert(Unpickle[String].fromBytes(bb) == uuidStr)
         }
-        'uuidUpperCase {
+        "uuidUpperCase" - {
           val uuidStr = UUID.randomUUID().toString.toUpperCase
           val bb      = Pickle.intoBytes(uuidStr)
           assert(bb.limit() == 37)
           assert(Unpickle[String].fromBytes(bb) == uuidStr)
         }
-        'deduplication {
+        "deduplication" - {
           implicit def pstate = new PickleState(new EncoderSize, true, true)
           implicit def ustate = (b: ByteBuffer) => new UnpickleState(new DecoderSize(b), true, true)
           val data            = (0 until 10).map(i => s"testing${i / 10}")
@@ -318,156 +318,156 @@ object PickleTests extends TestSuite {
           assert(udata == data)
         }
       }
-      'Option - {
-        'some {
+      "Option" - {
+        "some" - {
           val bb = Pickle.intoBytes(Some("test"))
           assert(bb.limit() == 1 + 5)
           assert(Unpickle[Option[String]].fromBytes(bb).contains("test"))
         }
-        'none {
+        "none" - {
           val d: Option[String] = None
           val bb                = Pickle.intoBytes(d)
           assert(bb.limit() == 1)
           assert(Unpickle[Option[String]].fromBytes(bb).isEmpty)
         }
       }
-      'Duration - {
-        'finite {
+      "Duration" - {
+        "finite" - {
           val bb = Pickle.intoBytes(Duration.fromNanos(1000))
           assert(bb.limit() == 2)
           assert(Unpickle[Duration].fromBytes(bb) == Duration.fromNanos(1000))
         }
-        'finiteLarge {
+        "finiteLarge" - {
           val bb = Pickle.intoBytes(Duration.fromNanos(Int.MaxValue * 2L))
           assert(bb.limit() == 9)
           assert(Unpickle[Duration].fromBytes(bb) == Duration.fromNanos(Int.MaxValue * 2L))
         }
-        'infinite {
+        "infinite" - {
           val bb = Pickle.intoBytes(Duration.Inf)
           assert(bb.limit() == 1)
           assert(Unpickle[Duration].fromBytes(bb) == Duration.Inf)
         }
-        'minusInfinite {
+        "minusInfinite" - {
           val bb = Pickle.intoBytes(Duration.MinusInf)
           assert(bb.limit() == 1)
           assert(Unpickle[Duration].fromBytes(bb) == Duration.MinusInf)
         }
-        'undefined {
+        "undefined" - {
           val bb = Pickle.intoBytes(Duration.Undefined)
           assert(bb.limit() == 1)
           assert(Unpickle[Duration].fromBytes(bb) eq Duration.Undefined)
         }
       }
-      'UUID - {
-        'random {
+      "UUID" - {
+        "random" - {
           val uuid = nonZeroUuid
           val bb   = Pickle.intoBytes(uuid)
           assert(bb.limit() == 16)
           assert(Unpickle[UUID].fromBytes(bb) == uuid)
         }
-        'repeated {
+        "repeated" - {
           val uuid = nonZeroUuid
           val list = List(uuid, new UUID(uuid.getMostSignificantBits, uuid.getLeastSignificantBits))
           val bb   = Pickle.intoBytes(list)
           assert(bb.limit() == 33)
           assert(Unpickle[List[UUID]].fromBytes(bb) == list)
         }
-        'null {
+        "null" - {
           val uuid: UUID = null
           val bb         = Pickle.intoBytes(uuid)
           assert(bb.limit() == 17)
           assert(Option(Unpickle[UUID].fromBytes(bb)).isEmpty)
         }
-        'zero {
+        "zero" - {
           val uuid = new UUID(0, 0)
           val bb   = Pickle.intoBytes(uuid)
           assert(bb.limit() == 17)
           assert(Unpickle[UUID].fromBytes(bb) == uuid)
         }
       }
-      'Either - {
-        'left {
+      "Either" - {
+        "left" - {
           val e: Either[Int, String] = Left(5)
           val bb                     = Pickle.intoBytes(e)
           assert(bb.limit() == 1 + 1)
           assert(Unpickle[Either[Int, String]].fromBytes(bb) == Left(5))
         }
-        'right {
+        "right" - {
           val e: Either[Int, String] = Right("Error!")
           val bb                     = Pickle.intoBytes(e)
           assert(bb.limit() == 1 + 7)
           assert(Unpickle[Either[Int, String]].fromBytes(bb) == Right("Error!"))
         }
       }
-      'Tuples - {
-        'tuple2 {
+      "Tuples" - {
+        "tuple2" - {
           val bb = Pickle.intoBytes(("Hello", Some("World")))
           assert(bb.limit() == 6 + 1 + 6)
           assert(Unpickle[(String, Option[String])].fromBytes(bb) == (("Hello", Some("World"))))
         }
       }
-      'Seq - {
-        'empty {
+      "Seq" - {
+        "empty" - {
           val bb = Pickle.intoBytes(Seq.empty[Int])
           assert(bb.limit() == 1)
           assert(Unpickle[Seq[Int]].fromBytes(bb) == Seq.empty[Int])
         }
-        'nulls {
+        "nulls" - {
           val bb = Pickle.intoBytes(Seq[String](null, "Test"))
           assert(bb.limit() == 1 + 2 + 5)
           assert(Unpickle[Seq[String]].fromBytes(bb) == Seq[String](null, "Test"))
         }
-        'singleEntry {
+        "singleEntry" - {
           val bb = Pickle.intoBytes(Seq(4095))
           assert(bb.limit() == 3)
           assert(Unpickle[Seq[Int]].fromBytes(bb) == Seq(4095))
         }
-        'seqOfSeq {
+        "seqOfSeq" - {
           val bb = Pickle.intoBytes(Seq(Seq(1), Seq(1, 2)))
           assert(bb.limit() == 1 + 2 + 3) // seq length, first subseq, second subseq
           assert(Unpickle[Seq[Seq[Int]]].fromBytes(bb) == Seq(Seq(1), Seq(1, 2)))
         }
-        'dupStrings {
+        "dupStrings" - {
           val bb = Pickle.intoBytes(Seq("test", "test", "test", "test"))
           //assert(bb.limit() == 1 + 5 + 3 * 2) // seq length, first "test", 3x reference
           assert(Unpickle[Seq[String]].fromBytes(bb) == Seq("test", "test", "test", "test"))
         }
-        'longSeq {
+        "longSeq" - {
           val data = Vector.tabulate[Int](10000)(x => -x)
           val bb   = Pickle.intoBytes(data)
           assert(bb.limit() == 25906)
           val u = Unpickle[Vector[Int]].fromBytes(bb)
           assert(u == data)
         }
-        'dupEmpty {
+        "dupEmpty" - {
           val data = Seq(Seq(), Seq("test"), Seq("test"), Seq(), Seq())
           val bb   = Pickle.intoBytes(data)
           assert(Unpickle[Seq[Seq[String]]].fromBytes(bb) == data)
         }
-        'tuples {
+        "tuples" - {
           val data: List[(String, String)] = List(("A", "B"), ("B", "C"))
           val bb                           = Pickle.intoBytes(data)
           val u                            = Unpickle[List[(String, String)]].fromBytes(bb)
           assert(u == data)
         }
       }
-      'Map - {
-        'empty {
+      "Map" - {
+        "empty" - {
           val bb = Pickle.intoBytes(Map.empty[String, Int])
           assert(bb.limit() == 1)
           assert(Unpickle[Map[String, Int]].fromBytes(bb) == Map.empty[String, Int])
         }
-        'simple {
+        "simple" - {
           val bb = Pickle.intoBytes(Map(1 -> 2, 5 -> 8000))
           assert(bb.limit() == 1 + 2 + 4)
           assert(Unpickle[Map[Int, Int]].fromBytes(bb) == Map(1 -> 2, 5 -> 8000))
         }
-        'mutable {
+        "mutable" - {
           val bb = Pickle.intoBytes(mutable.HashMap(1 -> 2))
           assert(bb.limit() == 3)
           assert(Unpickle[mutable.HashMap[Int, Int]].fromBytes(bb) == mutable.HashMap(1 -> 2))
         }
-        'large {
+        "large" - {
           val largeStringIntMap: Map[String, Int] = {
             val r = new Random(0)
             (for (i <- 0 until 10000) yield s"ID$i" -> (1.0 / (1.0 + r.nextDouble() * 1e5) * 1e7).toInt).toMap
@@ -475,55 +475,55 @@ object PickleTests extends TestSuite {
           val bb = Pickle.intoBytes(largeStringIntMap)
           assert(Unpickle[Map[String, Int]].fromBytes(bb) == largeStringIntMap)
         }
-        'complex {
+        "complex" - {
           val testMap = Map[String, Map[String, Int]]("test" -> Map[String, Int]("test2" -> 5))
           val bb      = Pickle.intoBytes(testMap)
           assert(Unpickle[Map[String, Map[String, Int]]].fromBytes(bb) == testMap)
         }
       }
-      'Set - {
-        'empty {
+      "Set" - {
+        "empty" - {
           val bb = Pickle.intoBytes(Set.empty[String])
           assert(bb.limit() == 1)
           assert(Unpickle[Set[String]].fromBytes(bb) == Set.empty[String])
         }
-        'simple {
+        "simple" - {
           val bb = Pickle.intoBytes(Set(1, 2, -1))
           assert(bb.limit() == 1 + 1 + 1 + 2)
           assert(Unpickle[Set[Int]].fromBytes(bb) == Set(1, 2, -1))
         }
       }
-      'Array - {
-        'empty {
+      "Array" - {
+        "empty" - {
           val bb = Pickle.intoBytes(Array.empty[Int])
           assert(bb.limit() == 4)
           assert(Unpickle[Array[Int]].fromBytes(bb) sameElements Array.empty[Int])
         }
-        'simple {
+        "simple" - {
           val bb = Pickle.intoBytes(Array(0, 1, -1, -5555))
           assert(bb.limit() == 4 + 1 + 1 + 2 + 3)
           assert(Unpickle[Array[Int]].fromBytes(bb) sameElements Array(0, 1, -1, -5555))
         }
-        'bytes {
+        "bytes" - {
           val bb = Pickle.intoBytes(Array[Byte](0, 1, -1, -55))
           assert(bb.limit() == 4 + 4 * 1)
           assert(Unpickle[Array[Byte]].fromBytes(bb) sameElements Array[Byte](0, 1, -1, -55))
         }
-        'floats {
+        "floats" - {
           val bb = Pickle.intoBytes(Array[Float](0f, 1f, -1.5f, math.Pi.toFloat))
           assert(bb.limit() == 4 + 4 * 4)
           assert(Unpickle[Array[Float]].fromBytes(bb) sameElements Array[Float](0f, 1f, -1.5f, math.Pi.toFloat))
         }
-        'doubles {
+        "doubles" - {
           val bb = Pickle.intoBytes(Array[Double](0, 1.0, -1.5, math.Pi))
           assert(bb.limit() == 8 + 4 * 8)
           assert(Unpickle[Array[Double]].fromBytes(bb) sameElements Array[Double](0, 1.0, -1.5, math.Pi))
         }
-        'strings {
+        "strings" - {
           val bb = Pickle.intoBytes(Array("Hello", " ", "World!"))
           assert(Unpickle[Array[String]].fromBytes(bb) sameElements Array("Hello", " ", "World!"))
         }
-        'arrayOfArray {
+        "arrayOfArray" - {
           val bb = Pickle.intoBytes(Array(Array(0, 0, 0), Array(1, 1, 1)))
           assert(bb.limit() == 4 + 7 + 7)
           assert(
@@ -531,8 +531,8 @@ object PickleTests extends TestSuite {
                                         Array(Array(0, 0, 0), Array(1, 1, 1)).asInstanceOf[Array[Object]]))
         }
       }
-      'ByteBuffer - {
-        'small {
+      "ByteBuffer" - {
+        "small" - {
           val d = ByteBuffer.allocateDirect(256) // default byte order is Big Endian
           (0 until 256).map(b => d.put(b.toByte))
           d.flip()
@@ -543,7 +543,7 @@ object PickleTests extends TestSuite {
           assert(r.remaining() == 256)
           assert(r.compareTo(d) == 0)
         }
-        'complex {
+        "complex" - {
           val d                                  = Pickle.intoBytes("Testing") // BooPickle output is Little Endian
           val data: (String, ByteBuffer, String) = ("Hello", d, "World")
           val bb                                 = Pickle.intoBytes(data)
@@ -557,8 +557,8 @@ object PickleTests extends TestSuite {
           Array.empty[Int]
         }
       }
-      'IdentityDeduplication - {
-        'CaseClasses - {
+      "IdentityDeduplication" - {
+        "CaseClasses" - {
           implicit def pstate = new PickleState(new EncoderSize, true)
           implicit def ustate = (b: ByteBuffer) => new UnpickleState(new DecoderSize(b), true)
           case class Test(i: Int, s: String)
@@ -569,8 +569,8 @@ object PickleTests extends TestSuite {
         }
       }
       // Storing multiple separate pickles into the same ByteBuffer
-      'MultiPickle - {
-        'twoStrings {
+      "MultiPickle" - {
+        "twoStrings" - {
           val s  = Pickle("Hello")
           val bb = s.pickle("World").toByteBuffer
           assert(bb.limit() == 6 + 6)
@@ -578,7 +578,7 @@ object PickleTests extends TestSuite {
           assert(Unpickle[String].fromState(state) == "Hello")
           assert(Unpickle[String].fromState(state) == "World")
         }
-        'stringRef {
+        "stringRef" - {
           implicit def pstate = new PickleState(new EncoderSize, true, true)
 
           val s  = Pickle("Hello")
@@ -589,8 +589,8 @@ object PickleTests extends TestSuite {
           assert(Unpickle[String].fromState(state) == "Hello")
         }
       }
-      'CustomPickleState - {
-        'HeapBuffer {
+      "CustomPickleState" - {
+        "HeapBuffer" - {
           val state = new PickleState(new EncoderSize(new HeapByteBufferProvider))
           val s     = state.pickle("Hello")
           val bb    = s.toByteBuffer
@@ -600,14 +600,14 @@ object PickleTests extends TestSuite {
           assert(ba(0) == 5)
           assert(Unpickle[String].fromBytes(bb) == "Hello")
         }
-        'DirectBuffer {
+        "DirectBuffer" - {
           val state = new PickleState(new EncoderSize(new DirectByteBufferProvider))
           val s     = state.pickle("Hello")
           val bb    = s.toByteBuffer
           assert(bb.limit() == 6)
           assert(bb.isDirect)
         }
-        'NoDeDuplication {
+        "NoDeDuplication" - {
           val state = new PickleState(new EncoderSize, false)
           case class Test(i: Int, s: Int)
           val data = Test(42, 45)
@@ -618,207 +618,207 @@ object PickleTests extends TestSuite {
         }
       }
     }
-    'speedCodec - {
+    "speedCodec" - {
       import boopickle.SpeedOriented._
       //implicit def pstate = new PickleState(new EncoderSpeed)
       //implicit def ustate = (b: ByteBuffer) =>  new UnpickleState(new DecoderSpeed(b))
-      'Boolean - {
-        'true {
+      "Boolean" - {
+        "true" - {
           val bb = Pickle.intoBytes(true)
           assert(bb.limit() == 1)
           assert(Unpickle[Boolean].fromBytes(bb))
         }
-        'false {
+        "false" - {
           val bb = Pickle.intoBytes(false)
           assert(bb.limit() == 1)
           assert(!Unpickle[Boolean].fromBytes(bb))
         }
       }
-      'Byte - {
-        'zero {
+      "Byte" - {
+        "zero" - {
           val bb = Pickle.intoBytes(0.toByte)
           assert(bb.limit() == 1)
           assert(Unpickle[Byte].fromBytes(bb) == 0)
         }
-        'positive {
+        "positive" - {
           val bb = Pickle.intoBytes(50.toByte)
           assert(bb.limit() == 1)
           assert(Unpickle[Byte].fromBytes(bb) == 50)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-1.toByte)
           assert(bb.limit() == 1)
           assert(Unpickle[Byte].fromBytes(bb) == -1)
         }
       }
-      'Short - {
-        'zero {
+      "Short" - {
+        "zero" - {
           val bb = Pickle.intoBytes(0.toShort)
           assert(bb.limit() == 2)
           assert(Unpickle[Short].fromBytes(bb) == 0)
         }
-        'positive {
+        "positive" - {
           val bb = Pickle.intoBytes(0x4000.toShort)
           assert(bb.limit() == 2)
           assert(Unpickle[Short].fromBytes(bb) == 0x4000)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-1.toShort)
           assert(bb.limit() == 2)
           assert(Unpickle[Short].fromBytes(bb) == -1)
         }
       }
-      'Int - {
-        'zero {
+      "Int" - {
+        "zero" - {
           val bb = Pickle.intoBytes(0)
           assert(bb.limit() == 4)
           assert(Unpickle[Int].fromBytes(bb) == 0)
         }
-        'positive {
+        "positive" - {
           val bb = Pickle.intoBytes(1024)
           assert(bb.limit() == 4)
           assert(Unpickle[Int].fromBytes(bb) == 1024)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-1048577)
           assert(bb.limit() == 4)
           assert(Unpickle[Int].fromBytes(bb) == -1048577)
         }
-        'max {
+        "max" - {
           val bb = Pickle.intoBytes(Int.MaxValue)
           assert(bb.limit() == 4)
           assert(Unpickle[Int].fromBytes(bb) == Int.MaxValue)
         }
-        'min {
+        "min" - {
           val bb = Pickle.intoBytes(Int.MinValue)
           assert(bb.limit() == 4)
           assert(Unpickle[Int].fromBytes(bb) == Int.MinValue)
         }
       }
-      'Long - {
-        'positive {
+      "Long" - {
+        "positive" - {
           val bb = Pickle.intoBytes(1024L * 1024L * 1024L * 1024L)
           assert(bb.limit() == 8)
           assert(Unpickle[Long].fromBytes(bb) == 1024L * 1024L * 1024L * 1024L)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-1024L * 1024L * 1024L * 1024L)
           assert(bb.limit() == 8)
           assert(Unpickle[Long].fromBytes(bb) == -1024L * 1024L * 1024L * 1024L)
         }
-        'max {
+        "max" - {
           val bb = Pickle.intoBytes(Long.MaxValue)
           assert(bb.limit() == 8)
           assert(Unpickle[Long].fromBytes(bb) == Long.MaxValue)
         }
-        'min {
+        "min" - {
           val bb = Pickle.intoBytes(Long.MinValue)
           assert(bb.limit() == 8)
           assert(Unpickle[Long].fromBytes(bb) == Long.MinValue)
         }
       }
-      'Float - {
-        'positive {
+      "Float" - {
+        "positive" - {
           val bb = Pickle.intoBytes(0.185f)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == 0.185f)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-0.185f)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == -0.185f)
         }
-        'max {
+        "max" - {
           val bb = Pickle.intoBytes(Float.MaxValue)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == Float.MaxValue)
         }
-        'min {
+        "min" - {
           val bb = Pickle.intoBytes(Float.MinValue)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == Float.MinValue)
         }
-        'infinity {
+        "infinity" - {
           val bb = Pickle.intoBytes(Float.PositiveInfinity)
           assert(bb.limit() == 4)
           assert(Unpickle[Float].fromBytes(bb) == Float.PositiveInfinity)
         }
       }
-      'Double - {
-        'positive {
+      "Double" - {
+        "positive" - {
           val bb = Pickle.intoBytes(math.Pi)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == math.Pi)
         }
-        'negative {
+        "negative" - {
           val bb = Pickle.intoBytes(-math.Pi)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == -math.Pi)
         }
-        'max {
+        "max" - {
           val bb = Pickle.intoBytes(Double.MaxValue)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == Double.MaxValue)
         }
-        'min {
+        "min" - {
           val bb = Pickle.intoBytes(Double.MinValue)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == Double.MinValue)
         }
-        'infinity {
+        "infinity" - {
           val bb = Pickle.intoBytes(Double.PositiveInfinity)
           assert(bb.limit() == 8)
           assert(Unpickle[Double].fromBytes(bb) == Double.PositiveInfinity)
         }
       }
-      'BigInt - {
-        'zero {
+      "BigInt" - {
+        "zero" - {
           val bb = Pickle.intoBytes(BigInt(0))
           assert(bb.limit() == 5)
           val bi = Unpickle[BigInt].fromBytes(bb)
           assert(bi == BigInt(0))
         }
-        'positive {
+        "positive" - {
           val value = BigInt("3031082301820398102312310273912739712397")
           val bb    = Pickle.intoBytes(value)
           assert(bb.limit() == value.toByteArray.length + 4)
           assert(Unpickle[BigInt].fromBytes(bb) == value)
         }
-        'negative {
+        "negative" - {
           val value = BigInt("-3031082301820398102312310273912739712397")
           val bb    = Pickle.intoBytes(value)
           assert(bb.limit() == value.toByteArray.length + 4)
           assert(Unpickle[BigInt].fromBytes(bb) == value)
         }
       }
-      'BigDecimal - {
-        'zero {
+      "BigDecimal" - {
+        "zero" - {
           val bb = Pickle.intoBytes(BigDecimal(0))
           assert(bb.limit() == 9)
           assert(Unpickle[BigDecimal].fromBytes(bb) == BigDecimal(0))
         }
-        'positive {
+        "positive" - {
           val value         = BigDecimal("3031082301820398102312310273912739712397.420348203423429374928374")
           val bb            = Pickle.intoBytes(value)
           val expectedLimit = value.underlying.unscaledValue.toByteArray.length + 4 + 4
           assert(bb.limit() == expectedLimit)
           assert(Unpickle[BigDecimal].fromBytes(bb) == value)
         }
-        'positiveZeroScale {
+        "positiveZeroScale" - {
           val value         = BigDecimal("3031082301820398102312310273912739712397420348203423429374928374")
           val bb            = Pickle.intoBytes(value)
           val expectedLimit = value.underlying.unscaledValue.toByteArray.length + 4 + 4
           assert(bb.limit() == expectedLimit)
           assert(Unpickle[BigDecimal].fromBytes(bb) == value)
         }
-        'negativeScale {
+        "negativeScale" - {
           val value         = BigDecimal("-3031082301820398102312310273912739712397.420348203423429374928374")
           val bb            = Pickle.intoBytes(value)
           val expectedLimit = value.underlying.unscaledValue.toByteArray.length + 4 + 4
           assert(bb.limit() == expectedLimit)
           assert(Unpickle[BigDecimal].fromBytes(bb) == value)
         }
-        'negativeZeroScale {
+        "negativeZeroScale" - {
           val value         = BigDecimal("-3031082301820398102312310273912739712397420348203423429374928374")
           val bb            = Pickle.intoBytes(value)
           val expectedLimit = value.underlying.unscaledValue.toByteArray.length + 4 + 4
@@ -826,224 +826,224 @@ object PickleTests extends TestSuite {
           assert(Unpickle[BigDecimal].fromBytes(bb) == value)
         }
       }
-      'String - {
-        'null {
+      "String" - {
+        "null" - {
           val str: String = null
           val bb          = Pickle.intoBytes(str)
           assert(bb.limit() == 4)
           assert(Unpickle[String].fromBytes(bb) == null)
         }
-        'empty {
+        "empty" - {
           val bb = Pickle.intoBytes("")
           assert(bb.limit() == 4)
           assert(Unpickle[String].fromBytes(bb) == "")
         }
-        'normal {
+        "normal" - {
           val bb = Pickle.intoBytes("normal")
           val s  = Unpickle[String].fromBytes(bb)
           assert(s == "normal")
         }
-        'unicode {
+        "unicode" - {
           val bb = Pickle.intoBytes("\uD834\uDF06泡菜")
           val s  = Unpickle[String].fromBytes(bb)
           assert(s == "\uD834\uDF06泡菜")
         }
-        'numeric {
+        "numeric" - {
           val bb = Pickle.intoBytes("100")
           assert(Unpickle[String].fromBytes(bb) == "100")
         }
-        'numericSmall {
+        "numericSmall" - {
           val bb = Pickle.intoBytes("5")
           assert(Unpickle[String].fromBytes(bb) == "5")
         }
-        'numericLarge {
+        "numericLarge" - {
           val bb = Pickle.intoBytes("-10000000000")
           assert(Unpickle[String].fromBytes(bb) == "-10000000000")
         }
-        'numeric20 {
+        "numeric20" - {
           val bb = Pickle.intoBytes("45248643522829592471")
           assert(Unpickle[String].fromBytes(bb) == "45248643522829592471")
         }
-        'numericStart {
+        "numericStart" - {
           val bb = Pickle.intoBytes("100x")
           assert(Unpickle[String].fromBytes(bb) == "100x")
         }
-        'numericZeros {
+        "numericZeros" - {
           val bb = Pickle.intoBytes("0100")
           assert(Unpickle[String].fromBytes(bb) == "0100")
         }
-        'uuid {
+        "uuid" - {
           val uuidStr = UUID.randomUUID().toString
           val bb      = Pickle.intoBytes(uuidStr)
           assert(Unpickle[String].fromBytes(bb) == uuidStr)
         }
-        'uuidUpperCase {
+        "uuidUpperCase" - {
           val uuidStr = UUID.randomUUID().toString.toUpperCase
           val bb      = Pickle.intoBytes(uuidStr)
           assert(Unpickle[String].fromBytes(bb) == uuidStr)
         }
       }
-      'Option - {
-        'null {
+      "Option" - {
+        "null" - {
           val bb = Pickle.intoBytes(null.asInstanceOf[Option[String]])
           assert(Unpickle[Option[String]].fromBytes(bb) == null)
         }
-        'some {
+        "some" - {
           val bb = Pickle.intoBytes(Some("test"))
           assert(Unpickle[Option[String]].fromBytes(bb).contains("test"))
         }
-        'none {
+        "none" - {
           val d: Option[String] = None
           val bb                = Pickle.intoBytes(d)
           assert(bb.limit() == 4)
           assert(Unpickle[Option[String]].fromBytes(bb).isEmpty)
         }
       }
-      'Duration - {
-        'null {
+      "Duration" - {
+        "null" - {
           val bb = Pickle.intoBytes(null.asInstanceOf[Duration])
           assert(Unpickle[Duration].fromBytes(bb) == null)
         }
-        'finite {
+        "finite" - {
           val bb = Pickle.intoBytes(Duration.fromNanos(1000))
           assert(bb.limit() == 9)
           assert(Unpickle[Duration].fromBytes(bb) == Duration.fromNanos(1000))
         }
-        'finiteLarge {
+        "finiteLarge" - {
           val bb = Pickle.intoBytes(Duration.fromNanos(Int.MaxValue * 2L))
           assert(bb.limit() == 9)
           assert(Unpickle[Duration].fromBytes(bb) == Duration.fromNanos(Int.MaxValue * 2L))
         }
-        'infinite {
+        "infinite" - {
           val bb = Pickle.intoBytes(Duration.Inf)
           assert(bb.limit() == 1)
           assert(Unpickle[Duration].fromBytes(bb) == Duration.Inf)
         }
-        'minusInfinite {
+        "minusInfinite" - {
           val bb = Pickle.intoBytes(Duration.MinusInf)
           assert(bb.limit() == 1)
           assert(Unpickle[Duration].fromBytes(bb) == Duration.MinusInf)
         }
-        'undefined {
+        "undefined" - {
           val bb = Pickle.intoBytes(Duration.Undefined)
           assert(bb.limit() == 1)
           assert(Unpickle[Duration].fromBytes(bb) eq Duration.Undefined)
         }
       }
-      'UUID - {
-        'random {
+      "UUID" - {
+        "random" - {
           val uuid = nonZeroUuid
           val bb   = Pickle.intoBytes(uuid)
           assert(bb.limit() == 16)
           assert(Unpickle[UUID].fromBytes(bb) == uuid)
         }
-        'repeated {
+        "repeated" - {
           val uuid = nonZeroUuid
           val list = List(uuid, new UUID(uuid.getMostSignificantBits, uuid.getLeastSignificantBits))
           val bb   = Pickle.intoBytes(list)
           assert(bb.limit() == 36)
           assert(Unpickle[List[UUID]].fromBytes(bb) == list)
         }
-        'null {
+        "null" - {
           val uuid: UUID = null
           val bb         = Pickle.intoBytes(uuid)
           assert(bb.limit() == 17)
           assert(Option(Unpickle[UUID].fromBytes(bb)).isEmpty)
         }
-        'zero {
+        "zero" - {
           val uuid = new UUID(0, 0)
           val bb   = Pickle.intoBytes(uuid)
           assert(bb.limit() == 17)
           assert(Unpickle[UUID].fromBytes(bb) == uuid)
         }
       }
-      'Either - {
-        'left {
+      "Either" - {
+        "left" - {
           val e: Either[Int, String] = Left(5)
           val bb                     = Pickle.intoBytes(e)
           assert(bb.limit() == 4 + 4)
           assert(Unpickle[Either[Int, String]].fromBytes(bb) == Left(5))
         }
-        'right {
+        "right" - {
           val e: Either[Int, String] = Right("Error!")
           val bb                     = Pickle.intoBytes(e)
           assert(Unpickle[Either[Int, String]].fromBytes(bb) == Right("Error!"))
         }
       }
-      'Tuples - {
-        'tuple2 {
+      "Tuples" - {
+        "tuple2" - {
           val bb = Pickle.intoBytes(("Hello", Some("World")))
           assert(Unpickle[(String, Option[String])].fromBytes(bb) == (("Hello", Some("World"))))
         }
       }
-      'Seq - {
-        'null {
+      "Seq" - {
+        "null" - {
           val bb = Pickle.intoBytes(null.asInstanceOf[Seq[String]])
           assert(Unpickle[Seq[String]].fromBytes(bb) == null)
         }
-        'empty {
+        "empty" - {
           val bb = Pickle.intoBytes(Seq.empty[Int])
           assert(bb.limit() == 4)
           assert(Unpickle[Seq[Int]].fromBytes(bb) == Seq.empty[Int])
         }
-        'nulls {
+        "nulls" - {
           val bb = Pickle.intoBytes(Seq[String](null, "Test"))
           assert(Unpickle[Seq[String]].fromBytes(bb) == Seq[String](null, "Test"))
         }
-        'singleEntry {
+        "singleEntry" - {
           val bb = Pickle.intoBytes(Seq(4095))
           assert(bb.limit() == 8)
           assert(Unpickle[Seq[Int]].fromBytes(bb) == Seq(4095))
         }
-        'seqOfSeq {
+        "seqOfSeq" - {
           val bb = Pickle.intoBytes(Seq(Seq(1), Seq(1, 2)))
           assert(bb.limit() == 4 + 8 + 12) // seq length, first subseq, second subseq
           assert(Unpickle[Seq[Seq[Int]]].fromBytes(bb) == Seq(Seq(1), Seq(1, 2)))
         }
-        'dupStrings {
+        "dupStrings" - {
           val bb = Pickle.intoBytes(Seq("test", "test", "test", "test"))
           assert(Unpickle[Seq[String]].fromBytes(bb) == Seq("test", "test", "test", "test"))
         }
-        'longSeq {
+        "longSeq" - {
           val data = Vector.tabulate[Int](10000)(x => -x)
           val bb   = Pickle.intoBytes(data)
           assert(bb.limit() == 40004)
           val u = Unpickle[Vector[Int]].fromBytes(bb)
           assert(u == data)
         }
-        'dupEmpty {
+        "dupEmpty" - {
           val data = Seq(Seq(), Seq("test"), Seq("test"), Seq(), Seq())
           val bb   = Pickle.intoBytes(data)
           assert(Unpickle[Seq[Seq[String]]].fromBytes(bb) == data)
         }
-        'tuples {
+        "tuples" - {
           val data: List[(String, String)] = List(("A", "B"), ("B", "C"))
           val bb                           = Pickle.intoBytes(data)
           val u                            = Unpickle[List[(String, String)]].fromBytes(bb)
           assert(u == data)
         }
       }
-      'Map - {
-        'null {
+      "Map" - {
+        "null" - {
           val bb = Pickle.intoBytes(null.asInstanceOf[Map[String, Int]])
           assert(Unpickle[Map[String, Int]].fromBytes(bb) == null)
         }
-        'empty {
+        "empty" - {
           val bb = Pickle.intoBytes(Map.empty[String, Int])
           assert(bb.limit() == 4)
           assert(Unpickle[Map[String, Int]].fromBytes(bb) == Map.empty[String, Int])
         }
-        'simple {
+        "simple" - {
           val bb = Pickle.intoBytes(Map(1 -> 2, 5 -> 8000))
           assert(bb.limit() == 4 + 8 + 8)
           assert(Unpickle[Map[Int, Int]].fromBytes(bb) == Map(1 -> 2, 5 -> 8000))
         }
-        'mutable {
+        "mutable" - {
           val bb = Pickle.intoBytes(mutable.HashMap(1 -> 2))
           assert(bb.limit() == 4 + 8)
           assert(Unpickle[mutable.HashMap[Int, Int]].fromBytes(bb) == mutable.HashMap(1 -> 2))
         }
-        'large {
+        "large" - {
           val largeStringIntMap: Map[String, Int] = {
             val r = new Random(0)
             (for (i <- 0 until 10000) yield s"ID$i" -> (1.0 / (1.0 + r.nextDouble() * 1e5) * 1e7).toInt).toMap
@@ -1051,63 +1051,63 @@ object PickleTests extends TestSuite {
           val bb = Pickle.intoBytes(largeStringIntMap)
           assert(Unpickle[Map[String, Int]].fromBytes(bb) == largeStringIntMap)
         }
-        'complex {
+        "complex" - {
           val testMap = Map[String, Map[String, Int]]("test" -> Map[String, Int]("test2" -> 5))
           val bb      = Pickle.intoBytes(testMap)
           assert(Unpickle[Map[String, Map[String, Int]]].fromBytes(bb) == testMap)
         }
       }
-      'Set - {
-        'null {
+      "Set" - {
+        "null" - {
           val bb = Pickle.intoBytes(null.asInstanceOf[Set[String]])
           assert(Unpickle[Set[String]].fromBytes(bb) == null)
         }
-        'empty {
+        "empty" - {
           val bb = Pickle.intoBytes(Set.empty[String])
           assert(bb.limit() == 4)
           assert(Unpickle[Set[String]].fromBytes(bb) == Set.empty[String])
         }
-        'simple {
+        "simple" - {
           val bb = Pickle.intoBytes(Set(1, 2, -1))
           assert(bb.limit() == 4 + 4 + 4 + 4)
           assert(Unpickle[Set[Int]].fromBytes(bb) == Set(1, 2, -1))
         }
       }
-      'Array - {
-        'null {
+      "Array" - {
+        "null" - {
           val bb = Pickle.intoBytes(null.asInstanceOf[Array[String]])
           assert(Unpickle[Array[String]].fromBytes(bb) == null)
         }
-        'empty {
+        "empty" - {
           val bb = Pickle.intoBytes(Array.empty[Int])
           assert(bb.limit() == 4)
           assert(Unpickle[Array[Int]].fromBytes(bb) sameElements Array.empty[Int])
         }
-        'ints {
+        "ints" - {
           val bb = Pickle.intoBytes(Array(0, 1, -1, -5555))
           assert(bb.limit() == 4 + 4 * 4)
           assert(Unpickle[Array[Int]].fromBytes(bb) sameElements Array(0, 1, -1, -5555))
         }
-        'bytes {
+        "bytes" - {
           val bb = Pickle.intoBytes(Array[Byte](0, 1, -1, -55))
           assert(bb.limit() == 4 + 4 * 1)
           assert(Unpickle[Array[Byte]].fromBytes(bb) sameElements Array[Byte](0, 1, -1, -55))
         }
-        'floats {
+        "floats" - {
           val bb = Pickle.intoBytes(Array[Float](0f, 1f, -1.5f, math.Pi.toFloat))
           assert(bb.limit() == 4 + 4 * 4)
           assert(Unpickle[Array[Float]].fromBytes(bb) sameElements Array[Float](0f, 1f, -1.5f, math.Pi.toFloat))
         }
-        'doubles {
+        "doubles" - {
           val bb = Pickle.intoBytes(Array[Double](0, 1.0, -1.5, math.Pi))
           assert(bb.limit() == 8 + 4 * 8)
           assert(Unpickle[Array[Double]].fromBytes(bb) sameElements Array[Double](0, 1.0, -1.5, math.Pi))
         }
-        'strings {
+        "strings" - {
           val bb = Pickle.intoBytes(Array("Hello", " ", "World!"))
           assert(Unpickle[Array[String]].fromBytes(bb) sameElements Array("Hello", " ", "World!"))
         }
-        'arrayOfArray {
+        "arrayOfArray" - {
           val bb = Pickle.intoBytes(Array(Array(0, 0, 0), Array(1, 1, 1)))
           assert(bb.limit() == 4 + 4 + 4 * 3 + 4 + 4 * 3)
           assert(
@@ -1115,8 +1115,8 @@ object PickleTests extends TestSuite {
                                         Array(Array(0, 0, 0), Array(1, 1, 1)).asInstanceOf[Array[Object]]))
         }
       }
-      'ByteBuffer - {
-        'small {
+      "ByteBuffer" - {
+        "small" - {
           val d = ByteBuffer.allocateDirect(256) // default byte order is Big Endian
           (0 until 256).map(b => d.put(b.toByte))
           d.flip()
@@ -1127,7 +1127,7 @@ object PickleTests extends TestSuite {
           assert(r.remaining() == 256)
           assert(r.compareTo(d) == 0)
         }
-        'complex {
+        "complex" - {
           val d    = Pickle.intoBytes("Testing") // BooPickle output is Little Endian
           val data = ("Hello", d, "World")
           val bb   = Pickle.intoBytes(data)
@@ -1139,8 +1139,8 @@ object PickleTests extends TestSuite {
           assert(rd == "Testing")
         }
       }
-      'IdentityDeduplication - {
-        'CaseClasses - {
+      "IdentityDeduplication" - {
+        "CaseClasses" - {
           case class Test(i: Int, s: String)
           val data = Test(42, "Earth")
           val bb   = Pickle.intoBytes(Seq(data, data, data))
@@ -1148,15 +1148,15 @@ object PickleTests extends TestSuite {
         }
       }
       // Storing multiple separate pickles into the same ByteBuffer
-      'MultiPickle - {
-        'twoStrings {
+      "MultiPickle" - {
+        "twoStrings" - {
           val s     = Pickle("Hello")
           val bb    = s.pickle("World").toByteBuffer
           val state = UnpickleState(new DecoderSpeed(bb))
           assert(Unpickle[String].fromState(state) == "Hello")
           assert(Unpickle[String].fromState(state) == "World")
         }
-        'stringRef {
+        "stringRef" - {
           val s     = Pickle("Hello")
           val bb    = s.pickle("Hello").toByteBuffer
           val state = UnpickleState(new DecoderSpeed(bb))
@@ -1164,8 +1164,8 @@ object PickleTests extends TestSuite {
           assert(Unpickle[String].fromState(state) == "Hello")
         }
       }
-      'CustomPickleState - {
-        'HeapBuffer {
+      "CustomPickleState" - {
+        "HeapBuffer" - {
           val state = new PickleState(new EncoderSpeed(new HeapByteBufferProvider))
           val s     = state.pickle("Hello")
           val bb    = s.toByteBuffer
@@ -1173,13 +1173,13 @@ object PickleTests extends TestSuite {
           val ba = bb.array
           assert(Unpickle[String].fromBytes(bb) == "Hello")
         }
-        'DirectBuffer {
+        "DirectBuffer" - {
           val state = new PickleState(new EncoderSpeed(new DirectByteBufferProvider))
           val s     = state.pickle("Hello")
           val bb    = s.toByteBuffer
           assert(bb.isDirect)
         }
-        'NoDeDuplication {
+        "NoDeDuplication" - {
           val state = new PickleState(new EncoderSpeed, false)
           case class Test(i: Int, s: Int)
           val data = Test(42, 45)

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ val commonSettings = Seq(
   Compile / scalacOptions ~= (_ filterNot (_ == "-Ywarn-value-discard")),
   testFrameworks += new TestFramework("utest.runner.Framework"),
   libraryDependencies ++= Seq(
-    "com.lihaoyi" %%% "utest" % "0.6.6" % Test,
+    "com.lihaoyi" %%% "utest" % "0.6.7" % Test,
     "org.scala-lang" % "scala-reflect" % scalaVersion.value % "provided"
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / scalafmtOnCompile := true
 val commonSettings = Seq(
   organization := "io.suzaku",
   version := Version.library,
-  crossScalaVersions := Seq("2.11.12", "2.12.6"),
+  crossScalaVersions := Seq("2.11.12", "2.12.6", "2.13.0-RC1"),
   scalaVersion in ThisBuild := "2.12.6",
   scalacOptions := Seq(
     "-deprecation",
@@ -18,16 +18,23 @@ val commonSettings = Seq(
     "-unchecked",
     "-Xfatal-warnings",
     "-Xlint",
-    "-Yno-adapted-args",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard",
-    "-Xfuture"
+    "-Ywarn-value-discard"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 12)) => Seq("-Xlint:-unused")
-    case _             => Nil
+    case Some((2, 13)) => Seq("-Xlint:-unused")
+    case Some((2, 12)) => Seq("-Xfuture", "-Xlint:-unused", "-Yno-adapted-args")
+    case _             => Seq("-Xfuture", "-Yno-adapted-args")
   }),
   Compile / scalacOptions ~= (_ filterNot (_ == "-Ywarn-value-discard")),
+  unmanagedSourceDirectories in Compile ++= {
+    (unmanagedSourceDirectories in Compile).value.map { dir =>
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, 13)) => file(dir.getPath ++ "-2.13+")
+        case _             => file(dir.getPath ++ "-2.13-")
+      }
+    }
+  },
   testFrameworks += new TestFramework("utest.runner.Framework"),
   libraryDependencies ++= Seq(
     "com.lihaoyi" %%% "utest" % "0.6.7" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -16,15 +16,14 @@ val commonSettings = Seq(
     "UTF-8",
     "-feature",
     "-unchecked",
-    "-Xfatal-warnings",
     "-Xlint",
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Ywarn-value-discard"
   ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 13)) => Seq("-Xlint:-unused")
-    case Some((2, 12)) => Seq("-Xfuture", "-Xlint:-unused", "-Yno-adapted-args")
-    case _             => Seq("-Xfuture", "-Yno-adapted-args")
+    case Some((2, 12)) => Seq("-Xfatal-warnings", "-Xfuture", "-Xlint:-unused", "-Yno-adapted-args")
+    case _             => Seq("-Xfatal-warnings", "-Xfuture", "-Yno-adapted-args")
   }),
   Compile / scalacOptions ~= (_ filterNot (_ == "-Ywarn-value-discard")),
   unmanagedSourceDirectories in Compile ++= {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.26")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.27")
 
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 

--- a/shapeless/src/test/scala/boopickle/shapeless/external/ShapelessPickleTests.scala
+++ b/shapeless/src/test/scala/boopickle/shapeless/external/ShapelessPickleTests.scala
@@ -64,14 +64,14 @@ object ShapelessPickleTests extends TestSuite {
   case class Multi2[S, T](s: S, t: T) extends MultiT[S, T, String]
 
   override def tests = Tests {
-    'CaseClasses - {
-      'Case1 {
+    "CaseClasses" - {
+      "Case1" - {
         val bb = Pickle.intoBytes(Test1(5, "Hello!"))
         val u  = Unpickle[Test1].fromBytes(bb)
         assert(bb.limit() == 1 + 1 + 7 - 1)
         assert(u == Test1(5, "Hello!"))
       }
-      'SeqCase {
+      "SeqCase" - {
         implicit def pstate                              = new PickleState(new EncoderSize, true)
         implicit def ustate: ByteBuffer => UnpickleState = b => new UnpickleState(new DecoderSize(b), true)
         val t                                            = Test1(99, "Hello!")
@@ -81,89 +81,89 @@ object ShapelessPickleTests extends TestSuite {
         val u = Unpickle[Seq[Test1]].fromBytes(bb)
         assert(u == s)
       }
-      'Recursive {
+      "Recursive" - {
         val t  = List(Test2(1, Some(Test2(2, Some(Test2(3, None))))))
         val bb = Pickle.intoBytes(t)
         assert(bb.limit() == 13 - 3)
         val u = Unpickle[List[Test2]].fromBytes(bb)
         assert(u == t)
       }
-      'CaseObject {
+      "CaseObject" - {
         val bb = Pickle.intoBytes(TestO)
         // yea, pickling a case object takes no space at all :)
         assert(bb.limit() == 0)
         val u = Unpickle[TestO.type].fromBytes(bb)
         assert(u == TestO)
       }
-      'Trait {
+      "Trait" - {
         val t: Seq[MyTrait] = Seq(TT1(5), TT2("five", TT2("six", new TT3(42, "fortytwo"))))
         val bb              = Pickle.intoBytes(t)
         val u               = Unpickle[Seq[MyTrait]].fromBytes(bb)
         assert(u == t)
       }
-      'TraitToo {
+      "TraitToo" - {
         // the same test code twice, to check that additional .class files are not generated for the MyTrait pickler
         val t: Seq[MyTrait] = Seq(TT1(5), TT2("five", TT2("six", new TT3(42, "fortytwo"))))
         val bb              = Pickle.intoBytes(t)
         val u               = Unpickle[Seq[MyTrait]].fromBytes(bb)
         assert(u == t)
       }
-      'AbstractClass {
+      "AbstractClass" - {
         val t: List[AClass] = List(AB(5), AB(2))
         val bb              = Pickle.intoBytes(t)
         val u               = Unpickle[List[AClass]].fromBytes(bb)
         assert(u == t)
       }
-      'AbstractClass2 {
+      "AbstractClass2" - {
         val t: Seq[Version] = Seq(V1, V2)
         val bytes           = Pickle.intoBytes(t)
         val u               = Unpickle[Seq[Version]].fromBytes(bytes)
         assert(u == t)
       }
-      'CaseTupleList {
+      "CaseTupleList" - {
         val x  = A(List(B(List(Tuple2(2.0, 1.0)))))
         val bb = Pickle.intoBytes(x)
         val u  = Unpickle[A].fromBytes(bb)
         assert(x == u)
       }
-      'CaseTupleList2 {
+      "CaseTupleList2" - {
         implicit val bPickler = generatePickler[B]
         val x                 = A(List(B(List((2.0, 3.0)))))
         val bb                = Pickle.intoBytes(x)
         val u                 = Unpickle[A].fromBytes(bb)
         assert(x == u)
       }
-      'CaseTupleList3 {
+      "CaseTupleList3" - {
         val x  = List(B(List((2.0, 3.0))))
         val bb = Pickle.intoBytes(x)
         val u  = Unpickle[List[B]].fromBytes(bb)
         assert(x == u)
       }
-      'CaseGenericTraitAndCaseclass {
+      "CaseGenericTraitAndCaseclass" - {
         val x: A1Trait[Int] = A1[Int](2)
         val bb              = Pickle.intoBytes(x)
         val u               = Unpickle[A1Trait[Int]].fromBytes(bb)
         assert(x == u)
       }
-      'CaseGenericTraitAndCaseclass2 {
+      "CaseGenericTraitAndCaseclass2" - {
         val x: A1Trait[Double] = A1[Double](2.0)
         val bb                 = Pickle.intoBytes(x)
         val u                  = Unpickle[A1Trait[Double]].fromBytes(bb)
         assert(x == u)
       }
-      'ValueClass {
+      "ValueClass" - {
         val x: ValueClass = ValueClass(3)
         val bb            = Pickle.intoBytes(x)
         val u             = Unpickle[ValueClass].fromBytes(bb)
         assert(x == u)
       }
-      'TraitAndValueClass {
+      "TraitAndValueClass" - {
         val x: ValueTrait[Int] = new ValueTraitClass[Int](3)
         val bb                 = Pickle.intoBytes(x)
         val u                  = Unpickle[ValueTrait[Int]].fromBytes(bb)
         assert(x == u)
       }
-      'MultipleGenerics {
+      "MultipleGenerics" - {
         val x: MultiT[Int, Double, String] = Multi[Int, Double](1, 2.0)
         val bb                             = Pickle.intoBytes(x)
         val u                              = Unpickle[MultiT[Int, Double, String]].fromBytes(bb)


### PR DESCRIPTION
Applying this PR will:

- update scalajs and utest
- add support for scala 2.13.0-RC1, closes #113 
- fix scala 2.13.0 deprecations and removals

Let me know if you like the approach I took, I'd be happy to make changes. There's one deprecation warning left: `UninitializedError` is deprecated since scala 2.12.7, see https://github.com/scala/scala/pull/7073.