### PR TITLE
Move oraclejdk to openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ scala:
 - 2.13.0
 sudo: false
 jdk:
-- oraclejdk8
-- oraclejdk9
+- openjdk8
+- openjdk9
 - openjdk10
 node_js:
 - 8


### PR DESCRIPTION
The CI fails because of the jdk specification. See here: https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038/2