### PR TITLE
Make Boopickle compiled with Java 9+ compatible with Java 8, close #124

### DIFF
--- a/boopickle/shared/src/main/scala/boopickle/BufferPool.scala
+++ b/boopickle/shared/src/main/scala/boopickle/BufferPool.scala
@@ -84,7 +84,7 @@ object BufferPool {
             val rNext = (rIdx + 1) % entryCount
             if (rNext != aIdx) {
               // try to release the buffer
-              bb.clear()
+              Java8BufferCompat.clear(bb)
               pool1(rNext) = bb
               releaseIdx1.compareAndSet(rIdx, rNext)
             }
@@ -94,7 +94,7 @@ object BufferPool {
             val rNext = (rIdx + 1) % entryCount
             if (rNext != aIdx) {
               // try to release the buffer
-              bb.clear()
+              Java8BufferCompat.clear(bb)
               pool0(rNext) = bb
               releaseIdx0.compareAndSet(rIdx, rNext)
             }

--- a/boopickle/shared/src/main/scala/boopickle/BufferProvider.scala
+++ b/boopickle/shared/src/main/scala/boopickle/BufferProvider.scala
@@ -38,7 +38,7 @@ abstract class ByteBufferProvider extends BufferProvider {
 
   final private def newBuffer(size: Int): Unit = {
     // flip current buffer (prepare for reading and set limit)
-    currentBuf.flip()
+    Java8BufferCompat.flip(currentBuf)
     buffers = currentBuf :: buffers
     // replace current buffer with the new one, align to 16-byte border for small sizes
     currentBuf = allocate((math.max(size, expandSize) & ~15) + 16)
@@ -51,7 +51,7 @@ abstract class ByteBufferProvider extends BufferProvider {
   }
 
   def asByteBuffer = {
-    currentBuf.flip()
+    Java8BufferCompat.flip(currentBuf)
     if (buffers.isEmpty)
       currentBuf
     else {
@@ -59,13 +59,13 @@ abstract class ByteBufferProvider extends BufferProvider {
       // create a new buffer and combine all buffers into it
       val comb = allocate(bufList.map(_.limit()).sum)
       bufList.foreach(buf => comb.put(buf))
-      comb.flip()
+      Java8BufferCompat.flip(comb)
       comb
     }
   }
 
   def asByteBuffers = {
-    currentBuf.flip()
+    Java8BufferCompat.flip(currentBuf)
     (currentBuf :: buffers).reverse.toVector
   }
 }
@@ -84,7 +84,7 @@ class HeapByteBufferProvider extends ByteBufferProvider {
   }
 
   override def asByteBuffer = {
-    currentBuf.flip()
+    Java8BufferCompat.flip(currentBuf)
     if (buffers.isEmpty)
       currentBuf
     else {
@@ -94,11 +94,11 @@ class HeapByteBufferProvider extends ByteBufferProvider {
       bufList.foreach { buf =>
         // use fast array copy
         java.lang.System.arraycopy(buf.array, buf.arrayOffset, comb.array, comb.position(), buf.limit())
-        comb.position(comb.position() + buf.limit())
+        Java8BufferCompat.position(comb, comb.position() + buf.limit())
         // release to the pool
         pool.release(buf)
       }
-      comb.flip()
+      Java8BufferCompat.flip(comb)
       comb
     }
   }
@@ -113,7 +113,7 @@ class DirectByteBufferProvider extends ByteBufferProvider {
   }
 
   override def asByteBuffer = {
-    currentBuf.flip()
+    Java8BufferCompat.flip(currentBuf)
     if (buffers.isEmpty)
       currentBuf
     else {
@@ -125,7 +125,7 @@ class DirectByteBufferProvider extends ByteBufferProvider {
         // release to the pool
         pool.release(buf)
       }
-      comb.flip()
+      Java8BufferCompat.flip(comb)
       comb
     }
   }

--- a/boopickle/shared/src/main/scala/boopickle/CodecSize.scala
+++ b/boopickle/shared/src/main/scala/boopickle/CodecSize.scala
@@ -480,12 +480,12 @@ class EncoderSize(bufferProvider: BufferProvider = DefaultByteBufferProvider.pro
     * @return
     */
   def writeByteBuffer(bb: ByteBuffer): Encoder = {
-    bb.mark()
+    Java8BufferCompat.mark(bb)
     val byteOrder = if (bb.order() == ByteOrder.BIG_ENDIAN) 1 else 0
     // encode byte order as bit 0 in the length
     writeInt(bb.remaining * 2 | byteOrder)
     alloc(bb.remaining).put(bb)
-    bb.reset()
+    Java8BufferCompat.reset(bb)
     this
   }
 

--- a/boopickle/shared/src/main/scala/boopickle/CodecSpeed.scala
+++ b/boopickle/shared/src/main/scala/boopickle/CodecSpeed.scala
@@ -326,12 +326,12 @@ class EncoderSpeed(bufferProvider: BufferProvider = DefaultByteBufferProvider.pr
     * @return
     */
   def writeByteBuffer(bb: ByteBuffer): Encoder = {
-    bb.mark()
+    Java8BufferCompat.mark(bb)
     val byteOrder = if (bb.order() == ByteOrder.BIG_ENDIAN) 1 else 0
     // encode byte order as bit 0 in the length
     writeInt(bb.remaining * 2 | byteOrder)
     alloc(bb.remaining).put(bb)
-    bb.reset()
+    Java8BufferCompat.reset(bb)
     this
   }
 

--- a/boopickle/shared/src/main/scala/boopickle/Java8BufferCompat.scala
+++ b/boopickle/shared/src/main/scala/boopickle/Java8BufferCompat.scala
@@ -1,0 +1,20 @@
+package boopickle
+
+import java.nio.Buffer
+
+/**
+ * Force linking to Buffer methods instead of ByteBuffer overloads
+ * to retain Java 8 compatibility
+ */
+private[boopickle] object Java8BufferCompat {
+
+  def flip(bb: Buffer): Unit = bb.flip()
+
+  def position(bb: Buffer, newPosition: Int): Unit = bb.position(newPosition)
+
+  def clear(bb: Buffer): Unit = bb.clear()
+
+  def mark(bb: Buffer): Unit = bb.mark()
+
+  def reset(bb: Buffer): Unit = bb.reset()
+}


### PR DESCRIPTION
Motivation:

Java 9 introduced several overloads to Buffer methods in ByteBuffer:

* position​(int newPosition)
* limit​(int newLimit)
* flip​()
* clear​()
* mark​()
* reset​()
* rewind​()

Compiling such code with Java 9+ with cause it to crash at runtime with Java 8 with NoSuchMethodError.

Modifications:

Introduce a `Java8BufferCompat` helper to force linking to `java.nio.Buffer` methods.

Result:

Boopickle can be compiled with Java 9+ and executed with Java 8.