### PR TITLE
Force `-release` scalac option to keep Java 8 compatibility, close #124

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ val commonSettings = Seq(
     case Some((2, 13)) => Seq("-Xlint:-unused")
     case Some((2, 12)) => Seq("-Xfatal-warnings", "-Xfuture", "-Xlint:-unused", "-Yno-adapted-args")
     case _             => Seq("-Xfatal-warnings", "-Xfuture", "-Yno-adapted-args")
-  }),
+  }) ++ (if (scala.util.Properties.javaVersion.startsWith("1.8")) Nil else Seq("-release", "8")),
   Compile / scalacOptions ~= (_ filterNot (_ == "-Ywarn-value-discard")),
   unmanagedSourceDirectories in Compile ++= {
     (unmanagedSourceDirectories in Compile).value.map { dir =>


### PR DESCRIPTION
Motivation:

Code compiled with Java 9+ might not be compatible at runtime with Java 8 because of new overloads that would generate NoSuchMethodError crashes.

Modification:

Force `-release` scalac option to `8` when compiling with Java 9++.

Result:

Boopickle can be compiled with Java 11 and still be compatible with Java 8.